### PR TITLE
release: v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "PengSheets" extension will be documented in this fil
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-02-24
+
 ### Fixed
 - Fix Doc tab in Single H1 workbook showing table icon and spreadsheet toolbar instead of file icon and no toolbar.
 - Fix edit mode for all Document tabs displaying `# title` header in textarea. Header is now omitted since tab name is editable via double-click.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "displayName": "PengSheets - Markdown Spreadsheet Editor",
     "description": "Transform Markdown tables into a powerful spreadsheet editor with Excel-like editing, multi-sheet workbooks, and real-time synchronization.",
     "icon": "images/icon.png",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "engines": {
         "vscode": "^1.90.0"
     },


### PR DESCRIPTION
Release v1.2.1

### Fixed
- Fix Doc tab in Single H1 workbook showing table icon and spreadsheet toolbar instead of file icon and no toolbar.
- Fix edit mode for all Document tabs displaying `# title` header in textarea. Header is now omitted since tab name is editable via double-click.
- Fix edit mode textarea opening scrolled to bottom instead of top.