### PR TITLE
feat: YAML frontmatter support (Document tab & virtual root)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "PengSheets" extension will be documented in this fil
 
 ## [Unreleased]
 
+### Added
+- Support YAML frontmatter with `title` field as an H1 equivalent, following a widely adopted convention.
+- Display a read-only header field above the editor in Document tab edit mode, showing the Markdown heading level (e.g. `## Title`).
+
+### Fixed
+- Fix empty table cells containing extra whitespace (`|  |` → `| |`).
+- Fix extra blank lines accumulating under Document tab headers on each cell edit in frontmatter workbooks.
+
 ## [1.2.1] - 2026-02-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
             "name": "peng-sheets",
             "version": "1.2.1",
             "dependencies": {
+                "js-yaml": "^4.1.1",
                 "md-spreadsheet-parser": "^1.4.2"
             },
             "devDependencies": {
                 "@open-wc/testing": "^4.0.0",
                 "@testing-library/dom": "^10.4.1",
                 "@types/glob": "^8.1.0",
+                "@types/js-yaml": "^4.0.9",
                 "@types/marked": "^5.0.2",
                 "@types/mocha": "^10.0.6",
                 "@types/node": "20.x",
@@ -1941,6 +1943,13 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "node_modules/@types/js-yaml": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+            "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/keygrip": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
@@ -3048,7 +3057,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
             "license": "Python-2.0"
         },
         "node_modules/aria-query": {
@@ -5318,7 +5326,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
             "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
     "name": "peng-sheets",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "peng-sheets",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "dependencies": {
-                "md-spreadsheet-parser": "^1.3.1"
+                "md-spreadsheet-parser": "^1.4.2"
             },
             "devDependencies": {
                 "@open-wc/testing": "^4.0.0",
@@ -5741,9 +5741,9 @@
             }
         },
         "node_modules/md-spreadsheet-parser": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/md-spreadsheet-parser/-/md-spreadsheet-parser-1.3.1.tgz",
-            "integrity": "sha512-+kBvgZcQLz6Fo7vpSB7qZOHD0ZArhrNnjxyyrxgEKk3StWxVjaVFclQ52a1svpndBPvRyVZqgdpCq17dTcxOeg==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/md-spreadsheet-parser/-/md-spreadsheet-parser-1.4.2.tgz",
+            "integrity": "sha512-y+zxA/ttwe8u3fNlijTLUu6wTgiHMj9K7CXZKeeS/QD8wAw9yNHJSH+roovOqWNLgpQFUZy+fU9oZIqg8TGnkA==",
             "license": "MIT",
             "dependencies": {
                 "@bytecodealliance/preview2-shim": "^0.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.2.1",
             "dependencies": {
                 "js-yaml": "^4.1.1",
-                "md-spreadsheet-parser": "^1.4.2"
+                "md-spreadsheet-parser": "^1.4.3"
             },
             "devDependencies": {
                 "@open-wc/testing": "^4.0.0",
@@ -5748,9 +5748,9 @@
             }
         },
         "node_modules/md-spreadsheet-parser": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/md-spreadsheet-parser/-/md-spreadsheet-parser-1.4.2.tgz",
-            "integrity": "sha512-y+zxA/ttwe8u3fNlijTLUu6wTgiHMj9K7CXZKeeS/QD8wAw9yNHJSH+roovOqWNLgpQFUZy+fU9oZIqg8TGnkA==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/md-spreadsheet-parser/-/md-spreadsheet-parser-1.4.3.tgz",
+            "integrity": "sha512-Q7Wyehv2NPCLbHrctEzDAqtiT4pGESHopwdAQAruESOrCpJkXn9BAQXVb4z39nfpKYvEu7AH2E+Ltdd95V+L6Q==",
             "license": "MIT",
             "dependencies": {
                 "@bytecodealliance/preview2-shim": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -241,6 +241,6 @@
     },
     "dependencies": {
         "js-yaml": "^4.1.1",
-        "md-spreadsheet-parser": "^1.4.2"
+        "md-spreadsheet-parser": "^1.4.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
         "@open-wc/testing": "^4.0.0",
         "@testing-library/dom": "^10.4.1",
         "@types/glob": "^8.1.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/marked": "^5.0.2",
         "@types/mocha": "^10.0.6",
         "@types/node": "20.x",
@@ -239,6 +240,7 @@
         "vitest": "^4.0.15"
     },
     "dependencies": {
+        "js-yaml": "^4.1.1",
         "md-spreadsheet-parser": "^1.4.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -239,6 +239,6 @@
         "vitest": "^4.0.15"
     },
     "dependencies": {
-        "md-spreadsheet-parser": "^1.3.1"
+        "md-spreadsheet-parser": "^1.4.2"
     }
 }

--- a/sample-workspace/frontmatter_multi_header.md
+++ b/sample-workspace/frontmatter_multi_header.md
@@ -1,0 +1,28 @@
+---
+id: 1234
+title: Frontmatter Document
+desc: ""
+updated: 1605266684036
+created: 1595961348801
+---
+
+This is the root doc.
+
+## Document Example
+
+This document is a fixed position document tab.
+
+# Workbook
+
+## Sheet 1
+
+### MyTable
+
+| Column 1 | Column 2 | Column 3 |
+| --- | --- | --- |
+|  | 200 | 100 |
+
+<!-- md-spreadsheet-sheet-metadata: {"layout": {"type": "pane", "id": "root", "tables": [0], "activeTableIndex": 0}} -->
+
+## Document 1
+

--- a/sample-workspace/frontmatter_workbook.md
+++ b/sample-workspace/frontmatter_workbook.md
@@ -1,0 +1,22 @@
+---
+id: root
+title: root
+desc: ""
+updated: 1605266684036
+created: 1595961348801
+---
+
+This is the root doc.
+
+## Sheet 1
+
+### MyTable
+
+| Column 1 | Column 2 | Column 3 |
+| --- | --- | --- |
+|  | 200 |  |
+
+<!-- md-spreadsheet-sheet-metadata: {"layout": {"type": "pane", "id": "root", "tables": [0], "activeTableIndex": 0}} -->
+
+## Document 1
+

--- a/src/editor/api.ts
+++ b/src/editor/api.ts
@@ -502,6 +502,27 @@ export function moveWorkbookSection(
     return documentService.moveWorkbookSection(getContext(), toDocIndex, toAfterDoc, toBeforeDoc, targetTabOrderIndex);
 }
 
+/**
+ * Update frontmatter body content (text between --- and first H1).
+ */
+export function updateFrontmatterContent(content: string): UpdateResult {
+    return documentService.updateFrontmatterContent(getContext(), content);
+}
+
+/**
+ * Rename frontmatter title field.
+ */
+export function renameFrontmatterTitle(newTitle: string): UpdateResult {
+    return documentService.renameFrontmatterTitle(getContext(), newTitle);
+}
+
+/**
+ * Delete frontmatter section (YAML block + body up to first H1).
+ */
+export function deleteFrontmatter(): UpdateResult {
+    return documentService.deleteFrontmatter(getContext());
+}
+
 // =============================================================================
 // Utility Functions
 // =============================================================================

--- a/src/editor/context.ts
+++ b/src/editor/context.ts
@@ -120,7 +120,15 @@ export class EditorContext {
             workbookJson = augmentWorkbookMetadata(workbookJson, this.state.mdText, rootMarker, sheetHeaderLevel);
 
             // Extract structure
-            const structureJson = extractStructure(this.state.mdText, rootMarker);
+            // For virtual root workbooks (rootMarker not in text), pass parser range.
+            // For normal workbooks, let extractStructure find it dynamically
+            // (parser line values become stale after mutations).
+            const wb = this.state.workbook;
+            const isVirtualRoot = !this.state.mdText.split('\n').some((line) => line.trim() === rootMarker);
+            const structureJson =
+                isVirtualRoot && wb.startLine !== undefined
+                    ? extractStructure(this.state.mdText, rootMarker, wb.startLine, wb.endLine)
+                    : extractStructure(this.state.mdText, rootMarker);
             structure = JSON.parse(structureJson);
         }
 
@@ -192,7 +200,13 @@ export class EditorContext {
                 effectiveConfig = JSON.stringify(configWithRootMarker);
             }
 
-            const tabOrder = initializeTabOrderFromStructure(mdText, effectiveConfig, numSheets);
+            const tabOrder = initializeTabOrderFromStructure(
+                mdText,
+                effectiveConfig,
+                numSheets,
+                workbook.startLine,
+                workbook.endLine
+            );
 
             const metadata = { ...(workbook.metadata || {}), tab_order: tabOrder };
             workbook = new Workbook({ ...workbook, metadata });

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -16,6 +16,7 @@ export type {
     StructureSection,
     DocumentSection,
     WorkbookSection,
+    FrontmatterSection,
     NumberFormat,
     ColumnFormat,
     ColumnMetadata,
@@ -33,3 +34,6 @@ export type {
 
 // Export context class for advanced usage
 export { EditorContext, getEditorContext } from './context';
+
+// Export structure utilities
+export { extractFrontmatter } from './utils/structure';

--- a/src/editor/services/document.ts
+++ b/src/editor/services/document.ts
@@ -46,10 +46,7 @@ export function getDocumentSectionRange(
     sectionIndex: number
 ): { startLine: number; endLine: number } | { error: string } {
     const mdText = context.mdText;
-    const configDict: EditorConfig = context.config ? JSON.parse(context.config) : {};
-    // workbook.name is just the name without the # prefix, so we need to add it
-    const wbName = context.workbook?.name;
-    const rootMarker = wbName ? `# ${wbName}` : (configDict.rootMarker ?? '# Workbook');
+    const [wbStart, wbEnd] = getWorkbookRangeFromContext(context);
 
     const lines = mdText.split('\n');
     let docIdx = 0;
@@ -62,17 +59,19 @@ export function getDocumentSectionRange(
             inCodeBlock = !inCodeBlock;
         }
 
-        if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
-            const stripped = line.trim();
-
-            // If we were tracking a document and hit ANY level-1 header, end it here
+        // Skip lines within the workbook range
+        if (i >= wbStart && i < wbEnd) {
+            // If we were tracking a document that ends at workbook start
             if (currentDocStart !== null) {
                 return { startLine: currentDocStart, endLine: i };
             }
+            continue;
+        }
 
-            if (stripped === rootMarker) {
-                // Workbook section - not a document, skip
-                continue;
+        if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
+            // If we were tracking a document and hit another H1, end it here
+            if (currentDocStart !== null) {
+                return { startLine: currentDocStart, endLine: i };
             }
 
             // Found a document section
@@ -105,9 +104,6 @@ export function addDocument(
     insertAfterTabOrderIndex = -1
 ): UpdateResult {
     const mdText = context.mdText;
-    const configDict: EditorConfig = context.config ? JSON.parse(context.config) : {};
-    const wbName = context.workbook?.name;
-    const rootMarker = wbName ? `# ${wbName}` : (configDict.rootMarker ?? '# Workbook');
 
     const lines = mdText.split('\n');
     // Python uses insertLine = 0 by default (insert at beginning)
@@ -124,6 +120,9 @@ export function addDocument(
         insertLine = wbEnd;
         // No need to search for document positions - insert at workbook end
     } else {
+        // Get workbook range for exclusion
+        const [wbStart, wbEnd] = getWorkbookRangeFromContext(context);
+
         // Parse the structure to find insertion point
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
@@ -131,18 +130,21 @@ export function addDocument(
                 inCodeBlock = !inCodeBlock;
             }
 
-            if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
-                const stripped = line.trim();
-                if (stripped === rootMarker) {
-                    // Workbook found - skip it (not inserting after workbook)
-                    continue;
-                }
+            // Skip lines within the workbook range
+            if (i >= wbStart && i < wbEnd) {
+                continue;
+            }
 
+            if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
                 // Document found
                 if (afterDocIndex >= 0 && docCount === afterDocIndex) {
                     // Find end of this document
                     let nextI = i + 1;
                     while (nextI < lines.length) {
+                        // Skip workbook range
+                        if (nextI >= wbStart && nextI < wbEnd) {
+                            break;
+                        }
                         const nextLine = lines[nextI];
                         if (nextLine.trim().startsWith('```')) {
                             inCodeBlock = !inCodeBlock;
@@ -557,15 +559,12 @@ export function moveDocumentSection(
                     inCodeBlock = !inCodeBlock;
                 }
                 if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
-                    const stripped = line.trim();
-                    if (stripped !== rootMarker) {
-                        if (docIdx === toDocIndex) {
-                            insertLine = i;
-                            foundTarget = true;
-                            break;
-                        }
-                        docIdx++;
+                    if (docIdx === toDocIndex) {
+                        insertLine = i;
+                        foundTarget = true;
+                        break;
                     }
+                    docIdx++;
                 }
             }
             if (!foundTarget) {
@@ -620,35 +619,41 @@ export function moveDocumentSection(
             // Find the document at position (adjustedToDocIndex - 1) and get its END
             const targetDocIdx = adjustedToDocIndex - 1;
 
+            // Get workbook range once (outside loop)
+            const tempText2 = linesWithoutDoc.join('\n');
+            const [tempWbStart2, tempWbEnd2] = getWorkbookRange(tempText2, rootMarker, sheetHeaderLevel);
+
             for (let i = 0; i < linesWithoutDoc.length; i++) {
                 const line = linesWithoutDoc[i];
                 if (line.trim().startsWith('```')) {
                     inCodeBlock = !inCodeBlock;
                 }
 
+                // Skip workbook range
+                if (i >= tempWbStart2 && i < tempWbEnd2) {
+                    continue;
+                }
+
                 if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
-                    const stripped = line.trim();
-                    if (stripped !== rootMarker) {
-                        if (docIdx === targetDocIdx) {
-                            // Found the target doc - now find its END (next H1 or EOF)
-                            let endLine = linesWithoutDoc.length;
-                            let endCodeBlock = false;
-                            for (let j = i + 1; j < linesWithoutDoc.length; j++) {
-                                const nextLine = linesWithoutDoc[j];
-                                if (nextLine.trim().startsWith('```')) {
-                                    endCodeBlock = !endCodeBlock;
-                                }
-                                if (!endCodeBlock && nextLine.startsWith('# ') && !nextLine.startsWith('## ')) {
-                                    endLine = j;
-                                    break;
-                                }
+                    if (docIdx === targetDocIdx) {
+                        // Found the target doc - now find its END (next H1 or EOF)
+                        let endLine = linesWithoutDoc.length;
+                        let endCodeBlock = false;
+                        for (let j = i + 1; j < linesWithoutDoc.length; j++) {
+                            const nextLine = linesWithoutDoc[j];
+                            if (nextLine.trim().startsWith('```')) {
+                                endCodeBlock = !endCodeBlock;
                             }
-                            targetLine = endLine;
-                            foundTarget = true;
-                            break;
+                            if (!endCodeBlock && nextLine.startsWith('# ') && !nextLine.startsWith('## ')) {
+                                endLine = j;
+                                break;
+                            }
                         }
-                        docIdx++;
+                        targetLine = endLine;
+                        foundTarget = true;
+                        break;
                     }
+                    docIdx++;
                 }
             }
         }
@@ -769,8 +774,6 @@ export function moveWorkbookSection(
     _targetTabOrderIndex: number | null = null
 ): UpdateResult {
     const configDict: EditorConfig = context.config ? JSON.parse(context.config) : {};
-    const wbName = context.workbook?.name;
-    const rootMarker = wbName ? `# ${wbName}` : (configDict.rootMarker ?? '# Workbook');
     const _sheetHeaderLevel = configDict.sheetHeaderLevel ?? 2;
 
     const mdText = context.mdText;
@@ -806,15 +809,13 @@ export function moveWorkbookSection(
             }
 
             if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
-                const stripped = line.trim();
-                if (stripped !== rootMarker) {
-                    if (docIdx === toDocIndex && toBeforeDoc) {
-                        // For toBeforeDoc, insert before this document
-                        targetLine = i;
-                        break;
-                    }
-                    docIdx++;
+                // All H1s in linesWithoutWb are documents (workbook was removed)
+                if (docIdx === toDocIndex && toBeforeDoc) {
+                    // For toBeforeDoc, insert before this document
+                    targetLine = i;
+                    break;
                 }
+                docIdx++;
             }
         }
 
@@ -831,20 +832,16 @@ export function moveWorkbookSection(
                 }
 
                 if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
-                    const stripped = line.trim();
-
-                    // If we found the target doc and hit ANY level-1 header, end here
+                    // All H1s in linesWithoutWb are documents (workbook was removed)
                     if (foundDoc) {
                         targetLine = i;
                         break;
                     }
 
-                    if (stripped !== rootMarker) {
-                        if (docIdx === toDocIndex) {
-                            foundDoc = true;
-                        }
-                        docIdx++;
+                    if (docIdx === toDocIndex) {
+                        foundDoc = true;
                     }
+                    docIdx++;
                 }
             }
 

--- a/src/editor/services/document.ts
+++ b/src/editor/services/document.ts
@@ -895,3 +895,145 @@ export function moveWorkbookSection(
         file_changed: true
     };
 }
+
+// =============================================================================
+// Frontmatter Operations
+// =============================================================================
+
+/**
+ * Find the range of YAML frontmatter block and its body content.
+ * Returns null if no valid frontmatter is found.
+ *
+ * - yamlStart: line index of opening `---` (always 0)
+ * - yamlEnd: line index of closing `---`
+ * - bodyEnd: line index of first H1 header (or total lines if none)
+ */
+function getFrontmatterRange(lines: string[]): { yamlStart: number; yamlEnd: number; bodyEnd: number } | null {
+    if (lines.length === 0 || lines[0].trim() !== '---') {
+        return null;
+    }
+
+    // Find closing ---
+    let yamlEnd = -1;
+    for (let i = 1; i < lines.length; i++) {
+        if (lines[i].trim() === '---') {
+            yamlEnd = i;
+            break;
+        }
+    }
+    if (yamlEnd < 0) return null;
+
+    // Find first H1 (body extends from yamlEnd+1 to first H1 or EOF)
+    let bodyEnd = lines.length;
+    let inCodeBlock = false;
+    for (let i = yamlEnd + 1; i < lines.length; i++) {
+        if (lines[i].trim().startsWith('```')) inCodeBlock = !inCodeBlock;
+        if (!inCodeBlock && lines[i].startsWith('# ') && !lines[i].startsWith('## ')) {
+            bodyEnd = i;
+            break;
+        }
+    }
+
+    return { yamlStart: 0, yamlEnd, bodyEnd };
+}
+
+/**
+ * Update the body content of the frontmatter section.
+ * The body is the text between the closing `---` and the first H1 header.
+ */
+export function updateFrontmatterContent(context: EditorContext, content: string): UpdateResult {
+    const lines = context.mdText.split('\n');
+    const range = getFrontmatterRange(lines);
+    if (!range) {
+        return { error: 'No frontmatter found' };
+    }
+
+    const { yamlEnd, bodyEnd } = range;
+
+    // Build new body: blank line after ---, content, blank line before H1
+    // \n\n after --- creates a blank line separator; \n\n before H1 creates blank line before heading
+    const body = content.trim() ? '\n\n' + content.trimEnd() + '\n\n' : '\n\n';
+
+    // Replace lines between yamlEnd (inclusive of ---) and bodyEnd
+    const beforeLines = lines.slice(0, yamlEnd + 1); // includes the closing ---
+    const afterLines = lines.slice(bodyEnd);
+    const newMdText = beforeLines.join('\n') + body + afterLines.join('\n');
+    context.mdText = newMdText;
+
+    return {
+        content: newMdText,
+        startLine: 0,
+        endLine: lines.length - 1,
+        file_changed: true
+    };
+}
+
+/**
+ * Rename the frontmatter title field.
+ * Updates the `title:` value in the YAML frontmatter block.
+ */
+export function renameFrontmatterTitle(context: EditorContext, newTitle: string): UpdateResult {
+    const lines = context.mdText.split('\n');
+    const range = getFrontmatterRange(lines);
+    if (!range) {
+        return { error: 'No frontmatter found' };
+    }
+
+    const { yamlEnd } = range;
+
+    // Find and replace the title line within the YAML block
+    let titleFound = false;
+    for (let i = 1; i < yamlEnd; i++) {
+        const match = lines[i].match(/^title:\s*/);
+        if (match) {
+            lines[i] = `title: ${newTitle}`;
+            titleFound = true;
+            break;
+        }
+    }
+
+    if (!titleFound) {
+        return { error: 'No title field found in frontmatter' };
+    }
+
+    const newMdText = lines.join('\n');
+    context.mdText = newMdText;
+
+    return {
+        content: newMdText,
+        startLine: 0,
+        endLine: lines.length - 1,
+        file_changed: true
+    };
+}
+
+/**
+ * Delete the frontmatter section entirely.
+ * Removes the YAML `---` block and all body content up to the first H1 header.
+ */
+export function deleteFrontmatter(context: EditorContext): UpdateResult {
+    const lines = context.mdText.split('\n');
+    const range = getFrontmatterRange(lines);
+    if (!range) {
+        return { error: 'No frontmatter found' };
+    }
+
+    const { bodyEnd } = range;
+
+    // Remove everything from start to bodyEnd
+    const afterLines = lines.slice(bodyEnd);
+    // Strip leading blank lines from the remaining content
+    let startIdx = 0;
+    while (startIdx < afterLines.length && afterLines[startIdx].trim() === '') {
+        startIdx++;
+    }
+    const newMdText = afterLines.slice(startIdx).join('\n');
+    context.mdText = newMdText;
+
+    return {
+        content: newMdText,
+        startLine: 0,
+        endLine: lines.length - 1,
+        file_changed: true
+    };
+}

--- a/src/editor/services/workbook.ts
+++ b/src/editor/services/workbook.ts
@@ -391,7 +391,28 @@ export function generateAndGetRange(context: EditorContext): UpdateResult {
     // Build rootMarker from workbook name or config
     const wbName = workbook?.name;
     const rootMarker = wbName ? `# ${wbName}` : (configDict.rootMarker ?? '# Workbook');
-    const [startLine, rawEndLine] = getWorkbookRange(mdText, rootMarker, sheetHeaderLevel);
+
+    // Use parser-detected range for virtual root workbooks (rootMarker not in text).
+    // For normal workbooks, use dynamic detection (parser values become stale after mutations).
+    let startLine: number;
+    let rawEndLine: number;
+    if (workbook?.startLine !== undefined && workbook?.endLine !== undefined) {
+        // Check if rootMarker actually exists in text
+        const lines = mdText.split('\n');
+        const rootInText = lines.some((line) => line.trim() === rootMarker);
+        if (rootInText) {
+            // Normal workbook: use dynamic detection
+            [startLine, rawEndLine] = getWorkbookRange(mdText, rootMarker, sheetHeaderLevel);
+        } else {
+            // Virtual root: workbook IS the entire file (no H1 boundary).
+            // Use parser startLine but endLine = EOF (parser endLine may not cover
+            // all H2 sections like doc sheets).
+            startLine = workbook.startLine;
+            rawEndLine = lines.length;
+        }
+    } else {
+        [startLine, rawEndLine] = getWorkbookRange(mdText, rootMarker, sheetHeaderLevel);
+    }
     const lines = mdText.split('\n');
 
     let endLine = rawEndLine;

--- a/src/editor/services/workbook.ts
+++ b/src/editor/services/workbook.ts
@@ -13,7 +13,9 @@ import type { UpdateResult, TabOrderItem, EditorConfig } from '../types';
 export function initializeTabOrderFromStructure(
     mdText: string,
     config: string | null,
-    numSheets: number
+    numSheets: number,
+    workbookStartLine?: number,
+    workbookEndLine?: number
 ): TabOrderItem[] {
     const configDict: EditorConfig = config ? JSON.parse(config) : {};
     const rootMarker = configDict.rootMarker ?? '# Workbook';
@@ -26,30 +28,45 @@ export function initializeTabOrderFromStructure(
         }));
     }
 
+    // Determine workbook range
+    const sheetHeaderLevel = configDict.sheetHeaderLevel ?? 2;
+    let wbStart: number;
+    let wbEnd: number;
+    if (workbookStartLine !== undefined && workbookEndLine !== undefined) {
+        wbStart = workbookStartLine;
+        wbEnd = workbookEndLine;
+    } else {
+        [wbStart, wbEnd] = getWorkbookRange(mdText, rootMarker, sheetHeaderLevel);
+    }
+
     const lines = mdText.split('\n');
     const tabOrder: TabOrderItem[] = [];
     let docIndex = 0;
     let workbookFound = false;
     let inCodeBlock = false;
 
-    for (const line of lines) {
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
         if (line.trim().startsWith('```')) {
             inCodeBlock = !inCodeBlock;
         }
 
-        if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
-            const stripped = line.trim();
-            if (stripped === rootMarker) {
-                // Workbook section - add all sheets at this position
+        // Skip lines within the workbook range
+        if (i >= wbStart && i < wbEnd) {
+            if (i === wbStart && !workbookFound) {
+                // Insert all sheets at the workbook's position
                 workbookFound = true;
-                for (let i = 0; i < numSheets; i++) {
-                    tabOrder.push({ type: 'sheet', index: i });
+                for (let s = 0; s < numSheets; s++) {
+                    tabOrder.push({ type: 'sheet', index: s });
                 }
-            } else {
-                // Document section
-                tabOrder.push({ type: 'document', index: docIndex });
-                docIndex++;
             }
+            continue;
+        }
+
+        if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
+            // Document section (outside workbook range)
+            tabOrder.push({ type: 'document', index: docIndex });
+            docIndex++;
         }
     }
 
@@ -305,17 +322,19 @@ export function generateAndGetRange(context: EditorContext): UpdateResult {
                 inCodeBlock = !inCodeBlock;
             }
 
+            // Skip lines within the workbook range
+            if (i >= wbStart && i < wbEnd) {
+                continue;
+            }
+
             if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
-                const stripped = line.trim();
-                if (stripped !== rootMarker) {
-                    // This is a document section
-                    if (i < wbStart) {
-                        docsBeforeWb.push(docIdx);
-                    } else if (i >= wbEnd) {
-                        docsAfterWb.push(docIdx);
-                    }
-                    docIdx++;
+                // This is a document section (outside workbook range)
+                if (i < wbStart) {
+                    docsBeforeWb.push(docIdx);
+                } else {
+                    docsAfterWb.push(docIdx);
                 }
+                docIdx++;
             }
         }
 

--- a/src/editor/services/workbook.ts
+++ b/src/editor/services/workbook.ts
@@ -431,7 +431,11 @@ export function generateAndGetRange(context: EditorContext): UpdateResult {
         }
     }
 
-    let content = newMd + '\n';
+    // Normalize consecutive blank lines: toMarkdown() may produce 3+ consecutive newlines
+    // (double blank lines) for doc sheets because the parser stores content with leading
+    // newlines. Collapse to max 2 consecutive newlines (= 1 blank line) to prevent
+    // accumulation on each parse-edit cycle. Then ensure single trailing newline.
+    let content = newMd.replace(/\n{3,}/g, '\n\n').replace(/\n+$/, '') + '\n';
 
     // Ensure empty line before appended content if file is not empty
     if (startLine >= lines.length && mdText) {

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -217,7 +217,13 @@ export interface WorkbookSection {
     type: 'workbook';
 }
 
-export type StructureSection = DocumentSection | WorkbookSection;
+export interface FrontmatterSection {
+    type: 'frontmatter';
+    title: string;
+    content: string;
+}
+
+export type StructureSection = DocumentSection | WorkbookSection | FrontmatterSection;
 
 // =============================================================================
 // Editor Config

--- a/src/editor/utils/structure.ts
+++ b/src/editor/utils/structure.ts
@@ -9,18 +9,76 @@ import type { StructureSection, DocumentSection, WorkbookSection } from '../type
  * Extract document and workbook structure from markdown text.
  * Returns a JSON string of StructureSection array.
  */
-export function extractStructure(mdText: string, rootMarker: string): string {
+export function extractStructure(
+    mdText: string,
+    rootMarker: string,
+    workbookStartLine?: number,
+    workbookEndLine?: number
+): string {
     const sections: StructureSection[] = [];
     const lines = mdText.split('\n');
+
+    // Determine workbook range
+    let wbStart: number;
+    let wbEnd: number;
+    if (workbookStartLine !== undefined && workbookEndLine !== undefined) {
+        wbStart = workbookStartLine;
+        wbEnd = workbookEndLine;
+    } else {
+        // Fallback: scan for rootMarker
+        wbStart = lines.length;
+        wbEnd = lines.length;
+        let inCB = false;
+        for (let i = 0; i < lines.length; i++) {
+            if (lines[i].trim().startsWith('```')) inCB = !inCB;
+            if (!inCB && lines[i].trim() === rootMarker) {
+                wbStart = i;
+                // Find end: next H1 or EOF
+                for (let j = i + 1; j < lines.length; j++) {
+                    if (lines[j].trim().startsWith('```')) inCB = !inCB;
+                    if (!inCB && lines[j].startsWith('# ') && !lines[j].startsWith('## ')) {
+                        wbEnd = j;
+                        break;
+                    }
+                }
+                if (wbEnd === lines.length) wbEnd = lines.length;
+                break;
+            }
+        }
+    }
 
     let currentType: 'document' | 'workbook' | null = null;
     let currentTitle: string | null = null;
     let currentLines: string[] = [];
     let inCodeBlock = false;
+    let workbookInserted = false;
 
-    for (const line of lines) {
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
         if (line.trim().startsWith('```')) {
             inCodeBlock = !inCodeBlock;
+        }
+
+        // At workbook start, flush current doc and insert workbook section
+        if (i === wbStart && !workbookInserted) {
+            if (currentTitle && currentType === 'document') {
+                sections.push({
+                    type: 'document',
+                    title: currentTitle,
+                    content: currentLines.join('\n')
+                } as DocumentSection);
+                currentTitle = null;
+            }
+            sections.push({ type: 'workbook' } as WorkbookSection);
+            currentType = 'workbook';
+            currentLines = [];
+            workbookInserted = true;
+            continue;
+        }
+
+        // Skip lines within workbook range
+        if (i >= wbStart && i < wbEnd) {
+            continue;
         }
 
         if (!inCodeBlock && line.startsWith('# ') && !line.startsWith('## ')) {
@@ -33,15 +91,8 @@ export function extractStructure(mdText: string, rootMarker: string): string {
                 } as DocumentSection);
             }
 
-            const stripped = line.trim();
-            if (stripped === rootMarker) {
-                sections.push({ type: 'workbook' } as WorkbookSection);
-                currentTitle = null;
-                currentType = 'workbook';
-            } else {
-                currentTitle = line.slice(2).trim();
-                currentType = 'document';
-            }
+            currentTitle = line.slice(2).trim();
+            currentType = 'document';
             currentLines = [];
         } else {
             if (currentType === 'document') {
@@ -79,6 +130,7 @@ export function augmentWorkbookMetadata(
     let inCodeBlock = false;
 
     if (rootMarker) {
+        let found = false;
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
             if (line.trim().startsWith('```')) {
@@ -86,8 +138,14 @@ export function augmentWorkbookMetadata(
             }
             if (!inCodeBlock && line.trim() === rootMarker) {
                 startIndex = i + 1;
+                found = true;
                 break;
             }
+        }
+        // Virtual root: rootMarker not found in text (e.g., frontmatter-based workbook)
+        // Start scanning from line 0
+        if (!found) {
+            startIndex = 0;
         }
     }
 

--- a/src/editor/utils/structure.ts
+++ b/src/editor/utils/structure.ts
@@ -4,6 +4,55 @@
  */
 
 import type { StructureSection, DocumentSection, WorkbookSection } from '../types';
+import * as yaml from 'js-yaml';
+
+/**
+ * Extract YAML frontmatter from markdown text.
+ * Returns the title and raw frontmatter content if frontmatter with a `title` field exists.
+ * Returns null if no frontmatter or no title field.
+ */
+export function extractFrontmatter(mdText: string): { title: string; content: string } | null {
+    const lines = mdText.split('\n');
+    if (lines.length === 0 || lines[0].trim() !== '---') {
+        return null;
+    }
+
+    // Find closing ---
+    let endIdx = -1;
+    for (let i = 1; i < lines.length; i++) {
+        if (lines[i].trim() === '---') {
+            endIdx = i;
+            break;
+        }
+    }
+    if (endIdx < 0) return null;
+
+    const yamlBlock = lines.slice(1, endIdx).join('\n');
+    try {
+        const parsed = yaml.load(yamlBlock) as Record<string, unknown> | null;
+        if (!parsed || typeof parsed !== 'object') return null;
+
+        const title = parsed.title;
+        if (!title || typeof title !== 'string') return null;
+
+        // Body content after frontmatter (until first H1 or EOF)
+        // Match VS Code markdown preview: never render YAML frontmatter block
+        const bodyLines: string[] = [];
+        for (let i = endIdx + 1; i < lines.length; i++) {
+            if (lines[i].startsWith('# ') && !lines[i].startsWith('## ')) {
+                break;
+            }
+            bodyLines.push(lines[i]);
+        }
+
+        return {
+            title: title.trim(),
+            content: bodyLines.join('\n').trim()
+        };
+    } catch {
+        return null;
+    }
+}
 
 /**
  * Extract document and workbook structure from markdown text.

--- a/webview-ui/components/bottom-tabs.ts
+++ b/webview-ui/components/bottom-tabs.ts
@@ -14,6 +14,8 @@ export interface TabDefinition {
     sheetIndex?: number;
     documentIndex?: number;
     index: number;
+    /** Pinned tabs are immovable (not draggable). Used for root and frontmatter tabs. */
+    pinned?: boolean;
 }
 
 /**
@@ -180,14 +182,14 @@ export class BottomTabs extends LitElement {
             activeElement.blur();
         }
 
-        if (tab.type === 'add-sheet' || tab.type === 'root') return;
+        if (tab.type === 'add-sheet' || tab.type === 'root' || tab.pinned) return;
         if (this.editingIndex === index) return;
         this._dragCtrl.startPotentialDrag(e, index);
     }
 
     private _handleMouseMove(e: MouseEvent, index: number, tab: TabDefinition) {
         if (!this._dragCtrl.isDragging) return;
-        if (tab.type === 'add-sheet' || tab.type === 'root') return;
+        if (tab.type === 'add-sheet' || tab.type === 'root' || tab.pinned) return;
 
         const target = e.currentTarget as HTMLElement;
         this._dragCtrl.updateDropTarget(index, target, e.clientX);
@@ -226,14 +228,14 @@ export class BottomTabs extends LitElement {
             <div class="bottom-tabs-container">
                 <div class="bottom-tabs" @scroll="${this._handleScroll}">
                     ${this.tabs.map(
-                        (tab, index) => html`
+            (tab, index) => html`
                             <div
                                 class="tab-item ${this.activeIndex === index ? 'active' : ''} ${tab.type === 'add-sheet'
-                                    ? 'add-sheet-tab'
-                                    : ''} ${isDragging && sourceIndex === index ? 'dragging' : ''} ${targetIndex ===
-                                    index && targetSide === 'left'
-                                    ? 'drag-over-left'
-                                    : ''} ${targetIndex === index && targetSide === 'right' ? 'drag-over-right' : ''}"
+                    ? 'add-sheet-tab'
+                    : ''} ${isDragging && sourceIndex === index ? 'dragging' : ''} ${targetIndex ===
+                        index && targetSide === 'left'
+                        ? 'drag-over-left'
+                        : ''} ${targetIndex === index && targetSide === 'right' ? 'drag-over-right' : ''}"
                                 @mousedown="${(e: MouseEvent) => this._handleMouseDown(e, index, tab)}"
                                 @mousemove="${(e: MouseEvent) => this._handleMouseMove(e, index, tab)}"
                                 @mouseleave="${this._handleMouseLeave}"
@@ -245,7 +247,7 @@ export class BottomTabs extends LitElement {
                             >
                                 ${this._renderTabIcon(tab)}
                                 ${this.editingIndex === index
-                                    ? html`
+                    ? html`
                                           <input
                                               class="tab-input"
                                               .value="${tab.title}"
@@ -256,10 +258,10 @@ export class BottomTabs extends LitElement {
                                               @blur="${(e: FocusEvent) => this._handleInputBlur(e, index, tab)}"
                                           />
                                       `
-                                    : html` ${tab.type !== 'add-sheet' ? tab.title : ''} `}
+                    : html` ${tab.type !== 'add-sheet' ? tab.title : ''} `}
                             </div>
                         `
-                    )}
+        )}
                 </div>
                 <div class="scroll-indicator-right ${this._isScrollableRight ? 'visible' : ''}"></div>
             </div>

--- a/webview-ui/components/bottom-tabs.ts
+++ b/webview-ui/components/bottom-tabs.ts
@@ -228,14 +228,14 @@ export class BottomTabs extends LitElement {
             <div class="bottom-tabs-container">
                 <div class="bottom-tabs" @scroll="${this._handleScroll}">
                     ${this.tabs.map(
-            (tab, index) => html`
+                        (tab, index) => html`
                             <div
                                 class="tab-item ${this.activeIndex === index ? 'active' : ''} ${tab.type === 'add-sheet'
-                    ? 'add-sheet-tab'
-                    : ''} ${isDragging && sourceIndex === index ? 'dragging' : ''} ${targetIndex ===
-                        index && targetSide === 'left'
-                        ? 'drag-over-left'
-                        : ''} ${targetIndex === index && targetSide === 'right' ? 'drag-over-right' : ''}"
+                                    ? 'add-sheet-tab'
+                                    : ''} ${isDragging && sourceIndex === index ? 'dragging' : ''} ${targetIndex ===
+                                    index && targetSide === 'left'
+                                    ? 'drag-over-left'
+                                    : ''} ${targetIndex === index && targetSide === 'right' ? 'drag-over-right' : ''}"
                                 @mousedown="${(e: MouseEvent) => this._handleMouseDown(e, index, tab)}"
                                 @mousemove="${(e: MouseEvent) => this._handleMouseMove(e, index, tab)}"
                                 @mouseleave="${this._handleMouseLeave}"
@@ -247,7 +247,7 @@ export class BottomTabs extends LitElement {
                             >
                                 ${this._renderTabIcon(tab)}
                                 ${this.editingIndex === index
-                    ? html`
+                                    ? html`
                                           <input
                                               class="tab-input"
                                               .value="${tab.title}"
@@ -258,10 +258,10 @@ export class BottomTabs extends LitElement {
                                               @blur="${(e: FocusEvent) => this._handleInputBlur(e, index, tab)}"
                                           />
                                       `
-                    : html` ${tab.type !== 'add-sheet' ? tab.title : ''} `}
+                                    : html` ${tab.type !== 'add-sheet' ? tab.title : ''} `}
                             </div>
                         `
-        )}
+                    )}
                 </div>
                 <div class="scroll-indicator-right ${this._isScrollableRight ? 'visible' : ''}"></div>
             </div>

--- a/webview-ui/components/spreadsheet-document-view.ts
+++ b/webview-ui/components/spreadsheet-document-view.ts
@@ -188,10 +188,8 @@ export class SpreadsheetDocumentView extends LitElement {
         return html`
             <div class="container">
                 ${this._isEditing
-                ? html`
-                          ${this.headerText
-                              ? html`<div class="header-field">${this.headerText}</div>`
-                              : html``}
+                    ? html`
+                          ${this.headerText ? html`<div class="header-field">${this.headerText}</div>` : html``}
                           <div class="edit-container">
                               <div class="edit-hint visible">${t('pressEscapeToCancel')}</div>
                               <textarea
@@ -211,7 +209,7 @@ export class SpreadsheetDocumentView extends LitElement {
                               Save
                           </button>
                       `
-                : html`
+                    : html`
                           <div class="output" @click=${this._enterEditMode}>
                               ${unsafeHTML(this._getRenderedContent())}
                           </div>

--- a/webview-ui/components/spreadsheet-document-view.ts
+++ b/webview-ui/components/spreadsheet-document-view.ts
@@ -24,6 +24,10 @@ export class SpreadsheetDocumentView extends LitElement {
     @property({ type: Boolean })
     isRootTab: boolean = false;
 
+    /** Raw markdown header text (e.g. "## Doc 1") or plain title for frontmatter */
+    @property({ type: String })
+    headerText: string = '';
+
     @property({ type: Number })
     sheetIndex: number = 0;
 
@@ -185,6 +189,9 @@ export class SpreadsheetDocumentView extends LitElement {
             <div class="container">
                 ${this._isEditing
                 ? html`
+                          ${this.headerText
+                              ? html`<div class="header-field">${this.headerText}</div>`
+                              : html``}
                           <div class="edit-container">
                               <div class="edit-hint visible">${t('pressEscapeToCancel')}</div>
                               <textarea

--- a/webview-ui/components/styles/document-view.css
+++ b/webview-ui/components/styles/document-view.css
@@ -21,6 +21,18 @@
     flex-direction: column;
 }
 
+/* Read-only header field */
+.header-field {
+    padding: 0.6rem 0.5rem;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 1.25em;
+    font-weight: bold;
+    color: var(--vscode-editor-foreground);
+    border-bottom: 1px solid var(--vscode-widget-border);
+    user-select: text;
+    flex-shrink: 0;
+}
+
 /* Rendered output */
 .output {
     margin: 0 0.5rem;
@@ -62,7 +74,7 @@
 .editor {
     flex: 1;
     min-height: 400px;
-    margin: 1.2rem 0.5rem;
+    margin: 0 0.5rem 1.2rem 0.5rem;
     padding: 0.5rem;
     font-family: var(--vscode-editor-font-family, monospace);
     font-size: var(--vscode-editor-font-size, 13px);

--- a/webview-ui/main.ts
+++ b/webview-ui/main.ts
@@ -641,12 +641,9 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
             return;
         }
 
-        // Use the docIndex tracked when the tab was created
+        // Pinned frontmatter tab: use frontmatter-specific API
         const docIndex = activeTab.docIndex;
-        if (docIndex === undefined) {
-            console.error('Document tab missing docIndex');
-            return;
-        }
+        const isFrontmatterTab = activeTab.pinned && docIndex === undefined;
 
         try {
             // Use title from event (may have been edited) or fall back to existing
@@ -655,7 +652,11 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
             // Use SpreadsheetService for unified handling (same pattern as DocSheet)
             // This handles batch processing and content formatting internally
             this.spreadsheetService.startBatch();
-            this.spreadsheetService.updateDocumentContent(docIndex, newTitle, detail.content);
+            if (isFrontmatterTab) {
+                this.spreadsheetService.updateFrontmatterContent(detail.content);
+            } else if (docIndex !== undefined) {
+                this.spreadsheetService.updateDocumentContent(docIndex, newTitle, detail.content);
+            }
             this.spreadsheetService.endBatch();
 
             // Update local state including title
@@ -962,18 +963,20 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                 : html``}
             <div class="content-area">
                 ${activeTab.type === 'sheet' && isSheetJSON(activeTab.data)
-                ? isDocSheetType(activeTab.data as SheetJSON)
-                    ? html`
+                    ? isDocSheetType(activeTab.data as SheetJSON)
+                        ? html`
                               <spreadsheet-document-view
                                   .title="${activeTab.title}"
                                   .content="${getSheetContent(activeTab.data as SheetJSON)}"
-                                  .headerText="${'#'.repeat((this.config as Record<string, number>)?.sheetHeaderLevel ?? 2)} ${activeTab.title}"
+                                  .headerText="${'#'.repeat(
+                                      (this.config as Record<string, number>)?.sheetHeaderLevel ?? 2
+                                  )} ${activeTab.title}"
                                   .isDocSheet="${true}"
                                   .sheetIndex="${activeTab.sheetIndex}"
                                   @toolbar-action="${this._handleToolbarAction}"
                               ></spreadsheet-document-view>
                           `
-                    : html`
+                        : html`
                               <div class="sheet-container" style="height: 100%">
                                   <layout-container
                                       .layout="${(activeTab.data as SheetJSON).metadata?.layout}"
@@ -981,14 +984,14 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                                       .sheetIndex="${activeTab.sheetIndex}"
                                       .workbook="${this.workbook}"
                                       .dateFormat="${((this.config?.validation as Record<string, unknown>)
-                            ?.dateFormat as string) || 'YYYY-MM-DD'}"
+                                          ?.dateFormat as string) || 'YYYY-MM-DD'}"
                                       @save-requested="${this._handleSave}"
                                       @selection-change="${this._handleSelectionChange}"
                                   ></layout-container>
                               </div>
                           `
-                : activeTab.type === 'document' && isDocumentJSON(activeTab.data)
-                    ? html`
+                    : activeTab.type === 'document' && isDocumentJSON(activeTab.data)
+                      ? html`
                             <spreadsheet-document-view
                                 .title="${activeTab.title}"
                                 .content="${(activeTab.data as DocumentJSON).content}"
@@ -996,7 +999,7 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                                 @toolbar-action="${this._handleToolbarAction}"
                             ></spreadsheet-document-view>
                         `
-                    : activeTab.type === 'root'
+                      : activeTab.type === 'root'
                         ? html`
                               <spreadsheet-document-view
                                   .title="${activeTab.title}"
@@ -1011,12 +1014,12 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                           `
                         : html``}
                 ${activeTab.type === 'onboarding'
-                ? html`
+                    ? html`
                           <spreadsheet-onboarding
                               @create-spreadsheet="${this._onCreateSpreadsheet}"
                           ></spreadsheet-onboarding>
                       `
-                : html``}
+                    : html``}
             </div>
 
             <bottom-tabs
@@ -1025,17 +1028,17 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                 .editingIndex="${this.editingTabIndex}"
                 @tab-select="${(e: CustomEvent) => (this.activeTabIndex = e.detail.index)}"
                 @tab-edit-start="${(e: CustomEvent) =>
-                this._handleTabDoubleClick(e.detail.index, this.tabs[e.detail.index])}"
+                    this._handleTabDoubleClick(e.detail.index, this.tabs[e.detail.index])}"
                 @tab-rename="${(e: CustomEvent) =>
-                this._handleTabRename(e.detail.index, e.detail.tab, e.detail.newName)}"
+                    this._handleTabRename(e.detail.index, e.detail.tab, e.detail.newName)}"
                 @tab-context-menu="${(e: CustomEvent) => {
-                this.tabContextMenu = {
-                    x: e.detail.x,
-                    y: e.detail.y,
-                    index: e.detail.index,
-                    tabType: e.detail.tabType
-                };
-            }}"
+                    this.tabContextMenu = {
+                        x: e.detail.x,
+                        y: e.detail.y,
+                        index: e.detail.index,
+                        tabType: e.detail.tabType
+                    };
+                }}"
                 @tab-reorder="${(e: CustomEvent) => this._handleTabReorder(e.detail.fromIndex, e.detail.toIndex)}"
                 @add-sheet-click="${this._handleAddSheet}"
             ></bottom-tabs>
@@ -1047,14 +1050,14 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                 .tabType="${this.tabContextMenu?.tabType ?? 'sheet'}"
                 @rename="${() => this._renameTab(this.tabContextMenu!.index)}"
                 @delete="${() => {
-                if (this.tabContextMenu?.tabType === 'sheet') {
-                    this._deleteSheet(this.tabContextMenu.index);
-                } else if (this.tabContextMenu?.tabType === 'root') {
-                    this._deleteRootContent(this.tabContextMenu.index);
-                } else {
-                    this._deleteDocument(this.tabContextMenu!.index);
-                }
-            }}"
+                    if (this.tabContextMenu?.tabType === 'sheet') {
+                        this._deleteSheet(this.tabContextMenu.index);
+                    } else if (this.tabContextMenu?.tabType === 'root') {
+                        this._deleteRootContent(this.tabContextMenu.index);
+                    } else {
+                        this._deleteDocument(this.tabContextMenu!.index);
+                    }
+                }}"
                 @add-document="${this._addDocumentFromMenu}"
                 @add-sheet="${this._addSheetFromMenu}"
                 @close="${() => (this.tabContextMenu = null)}"
@@ -1064,29 +1067,30 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
             <confirmation-modal
                 .open="${this.confirmDeleteIndex !== null}"
                 title="${this.confirmDeleteIndex !== null && this.tabs[this.confirmDeleteIndex]?.type === 'document'
-                ? t('deleteDocument')
-                : this.confirmDeleteIndex !== null && this.tabs[this.confirmDeleteIndex]?.type === 'root'
-                    ? t('deleteOverviewTab')
-                    : t('deleteSheet')}"
+                    ? t('deleteDocument')
+                    : this.confirmDeleteIndex !== null && this.tabs[this.confirmDeleteIndex]?.type === 'root'
+                      ? t('deleteOverviewTab')
+                      : t('deleteSheet')}"
                 confirmLabel="${t('delete')}"
                 cancelLabel="${t('cancel')}"
                 @confirm="${this._performDelete}"
                 @cancel="${this._cancelDelete}"
             >
                 ${unsafeHTML(
-                        this.confirmDeleteIndex !== null && this.tabs[this.confirmDeleteIndex]?.type === 'root'
-                            ? t('deleteOverviewTabConfirm')
-                            : t(
-                                this.confirmDeleteIndex !== null &&
-                                    this.tabs[this.confirmDeleteIndex]?.type === 'document'
-                                    ? 'deleteDocumentConfirm'
-                                    : 'deleteSheetConfirm',
-                                `<span style="color: var(--vscode-textPreformat-foreground);">${this.confirmDeleteIndex !== null
-                                    ? this.tabs[this.confirmDeleteIndex]?.title?.replace(/</g, '&lt;')
-                                    : ''
-                                }</span>`
-                            )
-                    )}
+                    this.confirmDeleteIndex !== null && this.tabs[this.confirmDeleteIndex]?.type === 'root'
+                        ? t('deleteOverviewTabConfirm')
+                        : t(
+                              this.confirmDeleteIndex !== null &&
+                                  this.tabs[this.confirmDeleteIndex]?.type === 'document'
+                                  ? 'deleteDocumentConfirm'
+                                  : 'deleteSheetConfirm',
+                              `<span style="color: var(--vscode-textPreformat-foreground);">${
+                                  this.confirmDeleteIndex !== null
+                                      ? this.tabs[this.confirmDeleteIndex]?.title?.replace(/</g, '&lt;')
+                                      : ''
+                              }</span>`
+                          )
+                )}
             </confirmation-modal>
 
             <add-tab-dropdown
@@ -1132,8 +1136,8 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
     private _deleteDocument(index: number) {
         this.tabContextMenu = null;
         const tab = this.tabs[index];
-        if (tab && tab.type === 'document' && typeof tab.docIndex === 'number') {
-            // Trigger modal for document deletion
+        if (tab && tab.type === 'document') {
+            // Trigger modal for document deletion (regular + pinned frontmatter)
             this.confirmDeleteIndex = index;
         }
     }
@@ -1314,6 +1318,9 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
         const tab = this.tabs[index];
         if (tab && tab.type === 'sheet' && typeof tab.sheetIndex === 'number') {
             this.spreadsheetService.deleteSheet(tab.sheetIndex);
+        } else if (tab && tab.type === 'document' && tab.pinned && tab.docIndex === undefined) {
+            // Pinned frontmatter tab: delete YAML block + body up to first H1
+            this.spreadsheetService.deleteFrontmatter();
         } else if (tab && tab.type === 'document' && typeof tab.docIndex === 'number') {
             this.spreadsheetService.deleteDocument(tab.docIndex);
         } else if (tab && tab.type === 'root') {
@@ -1329,6 +1336,9 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
 
         if (tab.type === 'sheet' && typeof tab.sheetIndex === 'number') {
             this.spreadsheetService.renameSheet(tab.sheetIndex, newName);
+        } else if (tab.type === 'document' && tab.pinned && tab.docIndex === undefined) {
+            // Pinned frontmatter tab: rename YAML title field
+            this.spreadsheetService.renameFrontmatterTitle(newName);
         } else if (tab.type === 'document' && typeof tab.docIndex === 'number') {
             this.spreadsheetService.renameDocument(tab.docIndex, newName);
         } else if (tab.type === 'root') {
@@ -1545,7 +1555,9 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                         data: { type: 'document', title: frontmatter.title, content: frontmatter.content }
                     });
                     // Re-index all tabs after unshift
-                    newTabs.forEach((tab, idx) => { tab.index = idx; });
+                    newTabs.forEach((tab, idx) => {
+                        tab.index = idx;
+                    });
                 }
             }
 

--- a/webview-ui/main.ts
+++ b/webview-ui/main.ts
@@ -1419,7 +1419,10 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
      */
     private _generateUniqueSheetName(): string {
         const prefix = t('sheetNamePrefix');
-        const existingNames = this.tabs.filter((tab) => tab.type === 'sheet').map((tab) => tab.title);
+        // Count only spreadsheet sheets, NOT doc sheets (which also have type='sheet')
+        const existingNames = this.tabs
+            .filter((tab) => tab.type === 'sheet' && isSheetJSON(tab.data) && !isDocSheetType(tab.data as SheetJSON))
+            .map((tab) => tab.title);
         // Start from total count + 1 to avoid cross-language duplicates
         // (e.g., "Sheet 1" exists → next should be "シート 2", not "シート 1")
         let i = existingNames.length + 1;
@@ -1433,9 +1436,15 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
      */
     private _generateUniqueDocName(): string {
         const prefix = t('documentNamePrefix');
-        // Count only document-type tabs, NOT sheets
+        // Count only user-created document tabs, NOT pinned frontmatter or root tabs
         const docNames = this.tabs
-            .filter((tab) => tab.type === 'document' || (tab.type === 'sheet' && isDocumentJSON(tab.data)))
+            .filter((tab) => {
+                // Doc sheets within workbook (type='sheet' with doc content)
+                if (tab.type === 'sheet' && isSheetJSON(tab.data) && isDocSheetType(tab.data as SheetJSON)) return true;
+                // Standalone document sections (type='document'), but NOT pinned frontmatter tabs
+                if (tab.type === 'document' && !tab.pinned) return true;
+                return false;
+            })
             .map((tab) => tab.title);
         // Start from doc count + 1 to avoid cross-language duplicates
         let i = docNames.length + 1;

--- a/webview-ui/main.ts
+++ b/webview-ui/main.ts
@@ -967,6 +967,7 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                               <spreadsheet-document-view
                                   .title="${activeTab.title}"
                                   .content="${getSheetContent(activeTab.data as SheetJSON)}"
+                                  .headerText="${'#'.repeat((this.config as Record<string, number>)?.sheetHeaderLevel ?? 2)} ${activeTab.title}"
                                   .isDocSheet="${true}"
                                   .sheetIndex="${activeTab.sheetIndex}"
                                   @toolbar-action="${this._handleToolbarAction}"
@@ -991,6 +992,7 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                             <spreadsheet-document-view
                                 .title="${activeTab.title}"
                                 .content="${(activeTab.data as DocumentJSON).content}"
+                                .headerText="${activeTab.pinned ? activeTab.title : `# ${activeTab.title}`}"
                                 @toolbar-action="${this._handleToolbarAction}"
                             ></spreadsheet-document-view>
                         `
@@ -999,6 +1001,9 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                               <spreadsheet-document-view
                                   .title="${activeTab.title}"
                                   .content="${(activeTab.data as { type: 'root'; content: string })?.content ?? ''}"
+                                  .headerText="${this.markdownInput?.trimStart().startsWith('---')
+                                      ? (this.workbook?.name ?? activeTab.title)
+                                      : `# ${this.workbook?.name ?? activeTab.title}`}"
                                   .isRootTab="${true}"
                                   @toolbar-action="${this._handleToolbarAction}"
                                   @root-content-change="${this._handleRootContentChange}"

--- a/webview-ui/main.ts
+++ b/webview-ui/main.ts
@@ -962,8 +962,8 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                 : html``}
             <div class="content-area">
                 ${activeTab.type === 'sheet' && isSheetJSON(activeTab.data)
-                    ? isDocSheetType(activeTab.data as SheetJSON)
-                        ? html`
+                ? isDocSheetType(activeTab.data as SheetJSON)
+                    ? html`
                               <spreadsheet-document-view
                                   .title="${activeTab.title}"
                                   .content="${getSheetContent(activeTab.data as SheetJSON)}"
@@ -972,7 +972,7 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                                   @toolbar-action="${this._handleToolbarAction}"
                               ></spreadsheet-document-view>
                           `
-                        : html`
+                    : html`
                               <div class="sheet-container" style="height: 100%">
                                   <layout-container
                                       .layout="${(activeTab.data as SheetJSON).metadata?.layout}"
@@ -980,21 +980,21 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                                       .sheetIndex="${activeTab.sheetIndex}"
                                       .workbook="${this.workbook}"
                                       .dateFormat="${((this.config?.validation as Record<string, unknown>)
-                                          ?.dateFormat as string) || 'YYYY-MM-DD'}"
+                            ?.dateFormat as string) || 'YYYY-MM-DD'}"
                                       @save-requested="${this._handleSave}"
                                       @selection-change="${this._handleSelectionChange}"
                                   ></layout-container>
                               </div>
                           `
-                    : activeTab.type === 'document' && isDocumentJSON(activeTab.data)
-                      ? html`
+                : activeTab.type === 'document' && isDocumentJSON(activeTab.data)
+                    ? html`
                             <spreadsheet-document-view
                                 .title="${activeTab.title}"
                                 .content="${(activeTab.data as DocumentJSON).content}"
                                 @toolbar-action="${this._handleToolbarAction}"
                             ></spreadsheet-document-view>
                         `
-                      : activeTab.type === 'root'
+                    : activeTab.type === 'root'
                         ? html`
                               <spreadsheet-document-view
                                   .title="${activeTab.title}"
@@ -1006,12 +1006,12 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                           `
                         : html``}
                 ${activeTab.type === 'onboarding'
-                    ? html`
+                ? html`
                           <spreadsheet-onboarding
                               @create-spreadsheet="${this._onCreateSpreadsheet}"
                           ></spreadsheet-onboarding>
                       `
-                    : html``}
+                : html``}
             </div>
 
             <bottom-tabs
@@ -1020,17 +1020,17 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                 .editingIndex="${this.editingTabIndex}"
                 @tab-select="${(e: CustomEvent) => (this.activeTabIndex = e.detail.index)}"
                 @tab-edit-start="${(e: CustomEvent) =>
-                    this._handleTabDoubleClick(e.detail.index, this.tabs[e.detail.index])}"
+                this._handleTabDoubleClick(e.detail.index, this.tabs[e.detail.index])}"
                 @tab-rename="${(e: CustomEvent) =>
-                    this._handleTabRename(e.detail.index, e.detail.tab, e.detail.newName)}"
+                this._handleTabRename(e.detail.index, e.detail.tab, e.detail.newName)}"
                 @tab-context-menu="${(e: CustomEvent) => {
-                    this.tabContextMenu = {
-                        x: e.detail.x,
-                        y: e.detail.y,
-                        index: e.detail.index,
-                        tabType: e.detail.tabType
-                    };
-                }}"
+                this.tabContextMenu = {
+                    x: e.detail.x,
+                    y: e.detail.y,
+                    index: e.detail.index,
+                    tabType: e.detail.tabType
+                };
+            }}"
                 @tab-reorder="${(e: CustomEvent) => this._handleTabReorder(e.detail.fromIndex, e.detail.toIndex)}"
                 @add-sheet-click="${this._handleAddSheet}"
             ></bottom-tabs>
@@ -1042,14 +1042,14 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                 .tabType="${this.tabContextMenu?.tabType ?? 'sheet'}"
                 @rename="${() => this._renameTab(this.tabContextMenu!.index)}"
                 @delete="${() => {
-                    if (this.tabContextMenu?.tabType === 'sheet') {
-                        this._deleteSheet(this.tabContextMenu.index);
-                    } else if (this.tabContextMenu?.tabType === 'root') {
-                        this._deleteRootContent(this.tabContextMenu.index);
-                    } else {
-                        this._deleteDocument(this.tabContextMenu!.index);
-                    }
-                }}"
+                if (this.tabContextMenu?.tabType === 'sheet') {
+                    this._deleteSheet(this.tabContextMenu.index);
+                } else if (this.tabContextMenu?.tabType === 'root') {
+                    this._deleteRootContent(this.tabContextMenu.index);
+                } else {
+                    this._deleteDocument(this.tabContextMenu!.index);
+                }
+            }}"
                 @add-document="${this._addDocumentFromMenu}"
                 @add-sheet="${this._addSheetFromMenu}"
                 @close="${() => (this.tabContextMenu = null)}"
@@ -1059,30 +1059,29 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
             <confirmation-modal
                 .open="${this.confirmDeleteIndex !== null}"
                 title="${this.confirmDeleteIndex !== null && this.tabs[this.confirmDeleteIndex]?.type === 'document'
-                    ? t('deleteDocument')
-                    : this.confirmDeleteIndex !== null && this.tabs[this.confirmDeleteIndex]?.type === 'root'
-                      ? t('deleteOverviewTab')
-                      : t('deleteSheet')}"
+                ? t('deleteDocument')
+                : this.confirmDeleteIndex !== null && this.tabs[this.confirmDeleteIndex]?.type === 'root'
+                    ? t('deleteOverviewTab')
+                    : t('deleteSheet')}"
                 confirmLabel="${t('delete')}"
                 cancelLabel="${t('cancel')}"
                 @confirm="${this._performDelete}"
                 @cancel="${this._cancelDelete}"
             >
                 ${unsafeHTML(
-                    this.confirmDeleteIndex !== null && this.tabs[this.confirmDeleteIndex]?.type === 'root'
-                        ? t('deleteOverviewTabConfirm')
-                        : t(
-                              this.confirmDeleteIndex !== null &&
-                                  this.tabs[this.confirmDeleteIndex]?.type === 'document'
-                                  ? 'deleteDocumentConfirm'
-                                  : 'deleteSheetConfirm',
-                              `<span style="color: var(--vscode-textPreformat-foreground);">${
-                                  this.confirmDeleteIndex !== null
-                                      ? this.tabs[this.confirmDeleteIndex]?.title?.replace(/</g, '&lt;')
-                                      : ''
-                              }</span>`
-                          )
-                )}
+                        this.confirmDeleteIndex !== null && this.tabs[this.confirmDeleteIndex]?.type === 'root'
+                            ? t('deleteOverviewTabConfirm')
+                            : t(
+                                this.confirmDeleteIndex !== null &&
+                                    this.tabs[this.confirmDeleteIndex]?.type === 'document'
+                                    ? 'deleteDocumentConfirm'
+                                    : 'deleteSheetConfirm',
+                                `<span style="color: var(--vscode-textPreformat-foreground);">${this.confirmDeleteIndex !== null
+                                    ? this.tabs[this.confirmDeleteIndex]?.title?.replace(/</g, '&lt;')
+                                    : ''
+                                }</span>`
+                            )
+                    )}
             </confirmation-modal>
 
             <add-tab-dropdown
@@ -1481,6 +1480,7 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                             type: 'root',
                             title: rootTabName,
                             index: newTabs.length,
+                            pinned: true,
                             data: { type: 'root', content: rootContent }
                         });
                     }
@@ -1503,6 +1503,35 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                             index: newTabs.length
                         });
                     }
+                }
+            }
+
+            // Detect frontmatter Document tab (Scenario B):
+            // Only when frontmatter has title AND actual H1 headers exist in text.
+            // For Scenario A (virtual root, no H1), frontmatter content is already
+            // in workbook.rootContent → Overview tab, so no separate tab is needed.
+            const textLines = this.markdownInput.split('\n');
+            let hasActualH1 = false;
+            let inCB = false;
+            for (const line of textLines) {
+                if (line.trim().startsWith('```')) inCB = !inCB;
+                if (!inCB && line.startsWith('# ') && !line.startsWith('## ')) {
+                    hasActualH1 = true;
+                    break;
+                }
+            }
+            if (hasActualH1) {
+                const frontmatter = editor.extractFrontmatter(this.markdownInput);
+                if (frontmatter) {
+                    newTabs.unshift({
+                        type: 'document',
+                        title: frontmatter.title,
+                        index: 0,
+                        pinned: true,
+                        data: { type: 'document', title: frontmatter.title, content: frontmatter.content }
+                    });
+                    // Re-index all tabs after unshift
+                    newTabs.forEach((tab, idx) => { tab.index = idx; });
                 }
             }
 
@@ -1533,8 +1562,8 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
             if (tabOrder && tabOrder.length > 0) {
                 const reorderedTabs: TabDefinition[] = [];
 
-                // Extract root tab first - it's always at position 0
-                const rootTab = newTabs.find((t) => t.type === 'root');
+                // Extract pinned tabs (root, frontmatter) - always at the beginning
+                const pinnedTabs = newTabs.filter((t) => t.pinned);
 
                 for (const orderItem of tabOrder) {
                     let matchedTab: TabDefinition | undefined;
@@ -1542,7 +1571,9 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                     if (orderItem.type === 'sheet') {
                         matchedTab = newTabs.find((t) => t.type === 'sheet' && t.sheetIndex === orderItem.index);
                     } else if (orderItem.type === 'document') {
-                        matchedTab = newTabs.find((t) => t.type === 'document' && t.docIndex === orderItem.index);
+                        matchedTab = newTabs.find(
+                            (t) => t.type === 'document' && !t.pinned && t.docIndex === orderItem.index
+                        );
                     }
 
                     if (matchedTab) {
@@ -1551,21 +1582,21 @@ export class MdSpreadsheetEditor extends LitElement implements GlobalEventHost {
                 }
 
                 // Add any tabs not in tab_order (onboarding, etc.) at the end
-                // EXCEPT add-sheet which should always be last, and root which is always first
+                // EXCEPT add-sheet which should always be last, and pinned tabs which are always first
                 let addSheetTab: TabDefinition | undefined;
                 for (const tab of newTabs) {
                     if (!reorderedTabs.includes(tab)) {
                         if (tab.type === 'add-sheet') {
                             addSheetTab = tab;
-                        } else if (tab.type !== 'root') {
+                        } else if (!tab.pinned) {
                             reorderedTabs.push(tab);
                         }
                     }
                 }
 
-                // Insert root tab at the very beginning
-                if (rootTab) {
-                    reorderedTabs.unshift(rootTab);
+                // Insert pinned tabs at the very beginning (in order)
+                for (let i = pinnedTabs.length - 1; i >= 0; i--) {
+                    reorderedTabs.unshift(pinnedTabs[i]);
                 }
                 // Always add add-sheet at the very end
                 if (addSheetTab) {

--- a/webview-ui/services/spreadsheet-service.ts
+++ b/webview-ui/services/spreadsheet-service.ts
@@ -611,6 +611,20 @@ export class SpreadsheetService {
         return editor.getDocumentSectionRange(docIndex);
     }
 
+    // --- Frontmatter Operations ---
+
+    public updateFrontmatterContent(content: string) {
+        this._performAction(() => editor.updateFrontmatterContent(content));
+    }
+
+    public renameFrontmatterTitle(newTitle: string) {
+        this._performAction(() => editor.renameFrontmatterTitle(newTitle));
+    }
+
+    public deleteFrontmatter() {
+        this._performAction(() => editor.deleteFrontmatter());
+    }
+
     // --- Workbook Initialization ---
 
     public async initializeWorkbook(mdText: string, config: unknown) {

--- a/webview-ui/tests/editor/frontmatter-operations.test.ts
+++ b/webview-ui/tests/editor/frontmatter-operations.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Frontmatter Operations Integration Tests
+ *
+ * Scope: Integration tests for updateFrontmatterContent, renameFrontmatterTitle,
+ *        and deleteFrontmatter editor APIs.
+ * Uses real module instances: initializeWorkbook → frontmatter APIs.
+ * No mocks — exercises the full parser → editor → text manipulation pipeline.
+ *
+ * Test Blueprint:
+ * - updateFrontmatterContent: body between --- and first H1 is replaced
+ * - renameFrontmatterTitle: YAML title field is updated, other fields preserved
+ * - deleteFrontmatter: YAML block + body up to first H1 are removed
+ * - Error states: no frontmatter, no title field
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    initializeWorkbook,
+    getState,
+    resetContext,
+    updateFrontmatterContent,
+    renameFrontmatterTitle,
+    deleteFrontmatter
+} from '../../../src/editor';
+
+const DEFAULT_CONFIG = JSON.stringify({});
+
+// Scenario B: frontmatter + H1 workbook (creates pinned frontmatter tab)
+const FRONTMATTER_WITH_H1 = `---
+id: 1234
+title: Frontmatter Document
+desc: ""
+updated: 1605266684036
+created: 1595961348801
+---
+
+This is the root doc.
+
+## Document Example
+
+This document is a fixed position document tab.
+
+# Workbook
+
+## Sheet 1
+
+### MyTable
+
+| Column 1 | Column 2 | Column 3 |
+| --- | --- | --- |
+|  | 200 | 100 |
+
+<!-- md-spreadsheet-sheet-metadata: {"layout": {"type": "pane", "id": "root", "tables": [0], "activeTableIndex": 0}} -->
+
+## Document 1
+
+`;
+
+// Edge case: frontmatter with empty body (YAML block only)
+const FRONTMATTER_EMPTY_BODY = `---
+id: 5678
+title: Empty Body Doc
+---
+
+# Workbook
+
+## Sheet 1
+
+### Table1
+
+| A | B |
+| --- | --- |
+| 1 | 2 |
+`;
+
+// Edge case: frontmatter-only file (no H1 at all)
+const FRONTMATTER_ONLY = `---
+title: Standalone
+---
+
+Some body content.
+`;
+
+describe('Frontmatter Operations Integration Tests', () => {
+    beforeEach(() => {
+        resetContext();
+    });
+
+    // =========================================================================
+    // updateFrontmatterContent
+    // =========================================================================
+    describe('updateFrontmatterContent', () => {
+        it('should replace body content between --- and first H1', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+
+            const result = updateFrontmatterContent('New body content.\n\nSecond paragraph.');
+
+            expect(result.error).toBeUndefined();
+            expect(result.content).toBeDefined();
+
+            // YAML block preserved
+            expect(result.content).toContain('---');
+            expect(result.content).toContain('title: Frontmatter Document');
+            expect(result.content).toContain('id: 1234');
+
+            // New body content present
+            expect(result.content).toContain('New body content.');
+            expect(result.content).toContain('Second paragraph.');
+
+            // Old body content removed
+            expect(result.content).not.toContain('This is the root doc.');
+            expect(result.content).not.toContain('## Document Example');
+            expect(result.content).not.toContain('fixed position document tab');
+
+            // Workbook section preserved
+            expect(result.content).toContain('# Workbook');
+            expect(result.content).toContain('## Sheet 1');
+            expect(result.content).toContain('## Document 1');
+
+            // CRITICAL: blank line must exist between body and H1 header
+            const lines = result.content!.split('\n');
+            const h1Idx = lines.findIndex((l) => l === '# Workbook');
+            expect(h1Idx).toBeGreaterThan(0);
+            // The line immediately before H1 should be empty (blank line separator)
+            expect(lines[h1Idx - 1]).toBe('');
+        });
+
+        it('should preserve blank line between empty body and H1', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+
+            const result = updateFrontmatterContent('');
+
+            expect(result.error).toBeUndefined();
+            expect(result.content).toContain('# Workbook');
+
+            // Even with empty body, blank line before H1 is required
+            const lines = result.content!.split('\n');
+            const h1Idx = lines.findIndex((l) => l === '# Workbook');
+            expect(h1Idx).toBeGreaterThan(0);
+            expect(lines[h1Idx - 1]).toBe('');
+        });
+
+        it('should normalize trailing newlines in content to exactly one blank line before H1', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+
+            // User enters content with multiple trailing newlines
+            const result = updateFrontmatterContent('Some content\n\n\n\n');
+
+            expect(result.error).toBeUndefined();
+            expect(result.content).toContain('Some content');
+            expect(result.content).toContain('# Workbook');
+
+            // Must have exactly 1 blank line before H1, not 4+
+            const lines = result.content!.split('\n');
+            const h1Idx = lines.findIndex((l) => l === '# Workbook');
+            expect(h1Idx).toBeGreaterThan(0);
+            // Line before H1 must be empty (blank line)
+            expect(lines[h1Idx - 1]).toBe('');
+            // But the line before that must NOT be empty (no double blank lines)
+            expect(lines[h1Idx - 2].trim()).not.toBe('');
+        });
+
+        it('should handle empty content (clearing body)', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+
+            const result = updateFrontmatterContent('');
+
+            expect(result.error).toBeUndefined();
+
+            // YAML preserved
+            expect(result.content).toContain('title: Frontmatter Document');
+
+            // Body cleared
+            expect(result.content).not.toContain('This is the root doc.');
+
+            // Workbook preserved
+            expect(result.content).toContain('# Workbook');
+        });
+
+        it('should return error when no frontmatter exists', () => {
+            const noFrontmatter = `# Workbook\n\n## Sheet 1\n\n| A |\n|---|\n| 1 |\n`;
+            initializeWorkbook(noFrontmatter, DEFAULT_CONFIG);
+
+            const result = updateFrontmatterContent('test');
+
+            expect(result.error).toBe('No frontmatter found');
+        });
+    });
+
+    // =========================================================================
+    // renameFrontmatterTitle
+    // =========================================================================
+    describe('renameFrontmatterTitle', () => {
+        it('should update the title field in YAML frontmatter', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+
+            const result = renameFrontmatterTitle('New Title');
+
+            expect(result.error).toBeUndefined();
+            expect(result.content).toBeDefined();
+
+            // New title present
+            expect(result.content).toContain('title: New Title');
+
+            // Old title removed
+            expect(result.content).not.toContain('title: Frontmatter Document');
+
+            // Other YAML fields preserved
+            expect(result.content).toContain('id: 1234');
+            expect(result.content).toContain('desc: ""');
+            expect(result.content).toContain('updated: 1605266684036');
+
+            // Body preserved
+            expect(result.content).toContain('This is the root doc.');
+
+            // Workbook preserved
+            expect(result.content).toContain('# Workbook');
+
+            // STRUCTURAL: blank line after closing --- (before body)
+            const lines = result.content!.split('\n');
+            const closingDashIdx = lines.indexOf('---', 1); // skip opening ---
+            expect(closingDashIdx).toBeGreaterThan(0);
+            expect(lines[closingDashIdx + 1]).toBe(''); // blank line after ---
+
+            // STRUCTURAL: blank line before H1 header
+            const h1Idx = lines.findIndex((l) => l === '# Workbook');
+            expect(h1Idx).toBeGreaterThan(0);
+            expect(lines[h1Idx - 1]).toBe(''); // blank line before # Workbook
+        });
+
+        it('should return error when no frontmatter exists', () => {
+            const noFrontmatter = `# Workbook\n\n## Sheet 1\n\n| A |\n|---|\n| 1 |\n`;
+            initializeWorkbook(noFrontmatter, DEFAULT_CONFIG);
+
+            const result = renameFrontmatterTitle('test');
+
+            expect(result.error).toBe('No frontmatter found');
+        });
+
+        it('should return error when no title field exists', () => {
+            const noTitle = `---\nid: 1234\ndesc: ""\n---\n\nbody\n\n# Workbook\n`;
+            initializeWorkbook(noTitle, DEFAULT_CONFIG);
+
+            const result = renameFrontmatterTitle('test');
+
+            expect(result.error).toBe('No title field found in frontmatter');
+        });
+    });
+
+    // =========================================================================
+    // deleteFrontmatter
+    // =========================================================================
+    describe('deleteFrontmatter', () => {
+        it('should remove YAML block and body up to first H1', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+
+            const result = deleteFrontmatter();
+
+            expect(result.error).toBeUndefined();
+            expect(result.content).toBeDefined();
+
+            // YAML block removed (check for --- as a standalone line, not in table separators)
+            const lines = result.content!.split('\n');
+            const yamlDelimiters = lines.filter((l) => l.trim() === '---');
+            expect(yamlDelimiters).toHaveLength(0);
+            expect(result.content).not.toContain('title: Frontmatter Document');
+            expect(result.content).not.toContain('id: 1234');
+
+            // Body removed
+            expect(result.content).not.toContain('This is the root doc.');
+            expect(result.content).not.toContain('## Document Example');
+
+            // Workbook section preserved intact
+            expect(result.content).toContain('# Workbook');
+            expect(result.content).toContain('## Sheet 1');
+            expect(result.content).toContain('### MyTable');
+            expect(result.content).toContain('## Document 1');
+
+            // STRUCTURAL: first line should be the H1 (no leading blank lines)
+            expect(lines[0]).toBe('# Workbook');
+
+            // STRUCTURAL: blank line after H1 preserved
+            expect(lines[1]).toBe('');
+
+            // Table data preserved with exact values
+            expect(result.content).toContain('| 200 |');
+            expect(result.content).toContain('| 100 |');
+
+            // Sheet metadata comment preserved
+            expect(result.content).toContain('md-spreadsheet-sheet-metadata');
+        });
+
+        it('delete result should re-parse as valid workbook', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+
+            const result = deleteFrontmatter();
+            expect(result.error).toBeUndefined();
+
+            // Re-init with deleted content (simulates VS Code re-parse)
+            resetContext();
+            initializeWorkbook(result.content!, DEFAULT_CONFIG);
+            const state = JSON.parse(getState());
+
+            // Should parse as valid workbook
+            expect(state.workbook).toBeDefined();
+            expect(state.workbook.name).toBe('Workbook');
+
+            // Sheets preserved (Sheet 1 = spreadsheet + Document 1 = doc sheet)
+            expect(state.workbook.sheets).toHaveLength(2);
+            expect(state.workbook.sheets[0].name).toBe('Sheet 1');
+
+            // Table data preserved
+            const table = state.workbook.sheets[0].tables[0];
+            expect(table).toBeDefined();
+            expect(table.rows[0][1]).toBe('200');
+            expect(table.rows[0][2]).toBe('100');
+
+            // No frontmatter section in structure
+            const fmSections = state.structure.filter((s: { type: string }) => s.type === 'frontmatter');
+            expect(fmSections).toHaveLength(0);
+
+            // Document 1 is a doc sheet within the workbook (sheets[1]), not a structure section
+            expect(state.workbook.sheets[1].name).toBe('Document 1');
+        });
+
+        it('should handle frontmatter with empty body', () => {
+            initializeWorkbook(FRONTMATTER_EMPTY_BODY, DEFAULT_CONFIG);
+
+            const result = deleteFrontmatter();
+
+            expect(result.error).toBeUndefined();
+
+            // YAML removed
+            expect(result.content).not.toContain('title: Empty Body Doc');
+
+            // Workbook preserved
+            expect(result.content).toContain('# Workbook');
+            expect(result.content).toContain('| 1 | 2 |');
+
+            // First line is H1
+            const lines = result.content!.split('\n');
+            expect(lines[0]).toBe('# Workbook');
+        });
+
+        it('should handle frontmatter-only file (no H1)', () => {
+            initializeWorkbook(FRONTMATTER_ONLY, DEFAULT_CONFIG);
+
+            const result = deleteFrontmatter();
+
+            expect(result.error).toBeUndefined();
+
+            // Everything removed — content should be empty or whitespace-only
+            expect(result.content!.trim()).toBe('');
+        });
+
+        it('should return error when no frontmatter exists', () => {
+            const noFrontmatter = `# Workbook\n\n## Sheet 1\n\n| A |\n|---|\n| 1 |\n`;
+            initializeWorkbook(noFrontmatter, DEFAULT_CONFIG);
+
+            const result = deleteFrontmatter();
+
+            expect(result.error).toBe('No frontmatter found');
+        });
+    });
+
+    // =========================================================================
+    // Idempotency / round-trip
+    // =========================================================================
+    describe('round-trip stability', () => {
+        it('update then rename should produce consistent result', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+
+            // Update body
+            const result1 = updateFrontmatterContent('Updated body');
+            expect(result1.error).toBeUndefined();
+
+            // Then rename title
+            const result2 = renameFrontmatterTitle('Renamed');
+            expect(result2.error).toBeUndefined();
+
+            // Both changes should be present
+            expect(result2.content).toContain('title: Renamed');
+            expect(result2.content).toContain('Updated body');
+
+            // Workbook intact
+            expect(result2.content).toContain('# Workbook');
+            expect(result2.content).toContain('## Sheet 1');
+        });
+
+        it('rename → re-init → edit body should preserve blank lines', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+
+            // Step 1: Rename
+            const renameResult = renameFrontmatterTitle('Renamed Title');
+            expect(renameResult.error).toBeUndefined();
+
+            // Step 2: Re-init with renamed content (simulates VS Code re-parse)
+            resetContext();
+            initializeWorkbook(renameResult.content!, DEFAULT_CONFIG);
+
+            // Step 3: Edit body content
+            const editResult = updateFrontmatterContent('New body after rename');
+            expect(editResult.error).toBeUndefined();
+
+            // Verify structural integrity
+            const lines = editResult.content!.split('\n');
+
+            // YAML block preserved with new title
+            expect(editResult.content).toContain('title: Renamed Title');
+
+            // Blank line after closing ---
+            const closingDashIdx = lines.indexOf('---', 1);
+            expect(closingDashIdx).toBeGreaterThan(0);
+            expect(lines[closingDashIdx + 1]).toBe('');
+
+            // Body content present
+            expect(editResult.content).toContain('New body after rename');
+
+            // Blank line before H1
+            const h1Idx = lines.findIndex((l) => l === '# Workbook');
+            expect(h1Idx).toBeGreaterThan(0);
+            expect(lines[h1Idx - 1]).toBe('');
+        });
+    });
+});

--- a/webview-ui/tests/editor/frontmatter-tab.test.ts
+++ b/webview-ui/tests/editor/frontmatter-tab.test.ts
@@ -1,6 +1,9 @@
 /**
  * Tests for extractFrontmatter utility function.
  *
+ * Scope: Unit tests for extractFrontmatter() in isolation.
+ * No mocks needed — pure function with string input/output.
+ *
  * Verifies YAML frontmatter detection and title extraction for
  * creating pinned document tabs.
  */
@@ -9,8 +12,9 @@ import { describe, it, expect } from 'vitest';
 import { extractFrontmatter } from '../../../src/editor/utils/structure';
 
 describe('extractFrontmatter', () => {
-    it('should extract title from valid frontmatter', () => {
-        const md = `---
+    describe('valid frontmatter with title', () => {
+        it('should return title and body content excluding YAML block', () => {
+            const md = `---
 title: My Daily Journal
 date: 2024-01-01
 ---
@@ -19,49 +23,20 @@ Some body content.
 
 # Workbook
 `;
-        const result = extractFrontmatter(md);
-        expect(result).not.toBeNull();
-        expect(result!.title).toBe('My Daily Journal');
-        expect(result!.content).not.toContain('title: My Daily Journal');
-        expect(result!.content).not.toContain('---');
-        expect(result!.content).toContain('Some body content.');
-    });
+            const result = extractFrontmatter(md);
 
-    it('should return null when no frontmatter exists', () => {
-        const md = `# Workbook
+            // Precondition: result exists
+            expect(result).not.toBeNull();
+            // Strict: exact title value
+            expect(result!.title).toBe('My Daily Journal');
+            // Strict: body content present, YAML frontmatter excluded
+            expect(result!.content).toContain('Some body content.');
+            expect(result!.content).not.toContain('title: My Daily Journal');
+            expect(result!.content).not.toContain('---');
+        });
 
-## Sheet 1
-
-| A |
-|---|
-| 1 |
-`;
-        expect(extractFrontmatter(md)).toBeNull();
-    });
-
-    it('should return null when frontmatter has no title', () => {
-        const md = `---
-date: 2024-01-01
-author: Test
----
-
-# Workbook
-`;
-        expect(extractFrontmatter(md)).toBeNull();
-    });
-
-    it('should return null for unclosed frontmatter', () => {
-        const md = `---
-title: Test
-This is not closed properly.
-
-# Workbook
-`;
-        expect(extractFrontmatter(md)).toBeNull();
-    });
-
-    it('should stop body content at first H1', () => {
-        const md = `---
+        it('should stop body content at first H1 and include H2', () => {
+            const md = `---
 title: root
 ---
 
@@ -73,29 +48,35 @@ Body before H1.
 
 ## Sheet 1
 `;
-        const result = extractFrontmatter(md);
-        expect(result).not.toBeNull();
-        expect(result!.content).toContain('Body before H1.');
-        expect(result!.content).toContain('## This is H2, not H1.');
-        expect(result!.content).not.toContain('# Workbook');
-    });
+            const result = extractFrontmatter(md);
 
-    it('should handle empty body after frontmatter', () => {
-        const md = `---
+            expect(result).not.toBeNull();
+            expect(result!.title).toBe('root');
+            // Body includes text before H1
+            expect(result!.content).toContain('Body before H1.');
+            // H2 is NOT an H1 boundary — should be included
+            expect(result!.content).toContain('## This is H2, not H1.');
+            // H1 and everything after it should be excluded
+            expect(result!.content).not.toContain('# Workbook');
+            expect(result!.content).not.toContain('## Sheet 1');
+        });
+
+        it('should return empty content when frontmatter is immediately followed by H1', () => {
+            const md = `---
 title: root
 ---
 # Workbook
 `;
-        const result = extractFrontmatter(md);
-        expect(result).not.toBeNull();
-        expect(result!.title).toBe('root');
-        // Content should NOT include the frontmatter block
-        expect(result!.content).not.toContain('title: root');
-        expect(result!.content).not.toContain('---');
-    });
+            const result = extractFrontmatter(md);
 
-    it('should handle frontmatter with special YAML characters', () => {
-        const md = `---
+            expect(result).not.toBeNull();
+            expect(result!.title).toBe('root');
+            // No body between frontmatter and H1 → content is empty
+            expect(result!.content).toBe('');
+        });
+
+        it('should parse YAML with special characters in title', () => {
+            const md = `---
 title: "My: Special & Title"
 tags: [a, b, c]
 ---
@@ -104,8 +85,89 @@ Content here.
 
 # Workbook
 `;
-        const result = extractFrontmatter(md);
-        expect(result).not.toBeNull();
-        expect(result!.title).toBe('My: Special & Title');
+            const result = extractFrontmatter(md);
+
+            expect(result).not.toBeNull();
+            // Strict: exact title with colon and ampersand
+            expect(result!.title).toBe('My: Special & Title');
+            // Verify content is also captured
+            expect(result!.content).toContain('Content here.');
+        });
+
+        it('should trim whitespace from title', () => {
+            const md = `---
+title: "  Padded Title  "
+---
+
+Body.
+# Workbook
+`;
+            const result = extractFrontmatter(md);
+
+            expect(result).not.toBeNull();
+            // Title should be trimmed
+            expect(result!.title).toBe('Padded Title');
+        });
+    });
+
+    describe('null return cases', () => {
+        it('should return null when no frontmatter exists', () => {
+            const md = `# Workbook
+
+## Sheet 1
+
+| A |
+|---|
+| 1 |
+`;
+            expect(extractFrontmatter(md)).toBeNull();
+        });
+
+        it('should return null when frontmatter has no title', () => {
+            const md = `---
+date: 2024-01-01
+author: Test
+---
+
+# Workbook
+`;
+            expect(extractFrontmatter(md)).toBeNull();
+        });
+
+        it('should return null for unclosed frontmatter delimiters', () => {
+            const md = `---
+title: Test
+This is not closed properly.
+
+# Workbook
+`;
+            expect(extractFrontmatter(md)).toBeNull();
+        });
+
+        it('should return null for empty string input', () => {
+            expect(extractFrontmatter('')).toBeNull();
+        });
+
+        it('should return null when title is empty string', () => {
+            const md = `---
+title: ""
+---
+
+Body.
+`;
+            // Empty title should not create a document tab
+            expect(extractFrontmatter(md)).toBeNull();
+        });
+
+        it('should return null when title is non-string type', () => {
+            const md = `---
+title: 42
+---
+
+Body.
+`;
+            // Numeric title should be rejected (must be a string)
+            expect(extractFrontmatter(md)).toBeNull();
+        });
     });
 });

--- a/webview-ui/tests/editor/frontmatter-tab.test.ts
+++ b/webview-ui/tests/editor/frontmatter-tab.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for extractFrontmatter utility function.
+ *
+ * Verifies YAML frontmatter detection and title extraction for
+ * creating pinned document tabs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractFrontmatter } from '../../../src/editor/utils/structure';
+
+describe('extractFrontmatter', () => {
+    it('should extract title from valid frontmatter', () => {
+        const md = `---
+title: My Daily Journal
+date: 2024-01-01
+---
+
+Some body content.
+
+# Workbook
+`;
+        const result = extractFrontmatter(md);
+        expect(result).not.toBeNull();
+        expect(result!.title).toBe('My Daily Journal');
+        expect(result!.content).not.toContain('title: My Daily Journal');
+        expect(result!.content).not.toContain('---');
+        expect(result!.content).toContain('Some body content.');
+    });
+
+    it('should return null when no frontmatter exists', () => {
+        const md = `# Workbook
+
+## Sheet 1
+
+| A |
+|---|
+| 1 |
+`;
+        expect(extractFrontmatter(md)).toBeNull();
+    });
+
+    it('should return null when frontmatter has no title', () => {
+        const md = `---
+date: 2024-01-01
+author: Test
+---
+
+# Workbook
+`;
+        expect(extractFrontmatter(md)).toBeNull();
+    });
+
+    it('should return null for unclosed frontmatter', () => {
+        const md = `---
+title: Test
+This is not closed properly.
+
+# Workbook
+`;
+        expect(extractFrontmatter(md)).toBeNull();
+    });
+
+    it('should stop body content at first H1', () => {
+        const md = `---
+title: root
+---
+
+Body before H1.
+
+## This is H2, not H1.
+
+# Workbook
+
+## Sheet 1
+`;
+        const result = extractFrontmatter(md);
+        expect(result).not.toBeNull();
+        expect(result!.content).toContain('Body before H1.');
+        expect(result!.content).toContain('## This is H2, not H1.');
+        expect(result!.content).not.toContain('# Workbook');
+    });
+
+    it('should handle empty body after frontmatter', () => {
+        const md = `---
+title: root
+---
+# Workbook
+`;
+        const result = extractFrontmatter(md);
+        expect(result).not.toBeNull();
+        expect(result!.title).toBe('root');
+        // Content should NOT include the frontmatter block
+        expect(result!.content).not.toContain('title: root');
+        expect(result!.content).not.toContain('---');
+    });
+
+    it('should handle frontmatter with special YAML characters', () => {
+        const md = `---
+title: "My: Special & Title"
+tags: [a, b, c]
+---
+
+Content here.
+
+# Workbook
+`;
+        const result = extractFrontmatter(md);
+        expect(result).not.toBeNull();
+        expect(result!.title).toBe('My: Special & Title');
+    });
+});

--- a/webview-ui/tests/editor/frontmatter-workbook.test.ts
+++ b/webview-ui/tests/editor/frontmatter-workbook.test.ts
@@ -1,16 +1,17 @@
 /**
  * Frontmatter Workbook Tests
  *
- * Tests for loading and operating on workbooks that use YAML frontmatter
- * as the workbook root (virtual root) instead of an explicit H1 header.
+ * Scope: Integration tests across editor modules.
+ * Uses real module instances: initializeWorkbook → getState/updateCell.
+ * No mocks — exercises the full parser → editor → markdown generation pipeline.
  *
  * Scenario A: Frontmatter title only (no H1 headers)
- *   → Parser treats frontmatter as workbook root
- *   → Editor must handle virtual root (rootMarker not in text)
+ *   → Parser treats frontmatter as workbook root (virtual root)
+ *   → Editor must handle rootMarker absent from text
  *
  * Scenario B: Frontmatter title + H1 headers
- *   → Parser treats H1 as workbook root, frontmatter as Document section
- *   → Editor works normally (H1 is in text)
+ *   → Parser treats H1 as workbook root, frontmatter as separate content
+ *   → Frontmatter becomes a pinned Document tab
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -18,12 +19,12 @@ import { initializeWorkbook, getState, resetContext, updateCell } from '../../..
 
 const DEFAULT_CONFIG = JSON.stringify({});
 
-describe('Frontmatter Workbook Tests', () => {
+describe('Frontmatter Workbook Integration Tests', () => {
     beforeEach(() => {
         resetContext();
     });
 
-    describe('Scenario A: Frontmatter-only workbook (no H1)', () => {
+    describe('Scenario A: Virtual root workbook (frontmatter only, no H1)', () => {
         const FRONTMATTER_ONLY = `---
 title: My Daily Journal
 date: 2024-01-01
@@ -42,56 +43,69 @@ date: 2024-01-01
 | 3 |
 `;
 
-        it('should parse frontmatter workbook and detect sheets', () => {
+        it('should use frontmatter title as workbook name and detect all sheets', () => {
             initializeWorkbook(FRONTMATTER_ONLY, DEFAULT_CONFIG);
             const state = JSON.parse(getState());
 
-            expect(state.workbook).not.toBeNull();
+            // Strict: exact workbook name from frontmatter title
             expect(state.workbook.name).toBe('My Daily Journal');
-            expect(state.workbook.sheets.length).toBe(2);
+            // Strict: exact sheet count and names
+            expect(state.workbook.sheets).toHaveLength(2);
             expect(state.workbook.sheets[0].name).toBe('Sheet 1');
             expect(state.workbook.sheets[1].name).toBe('Sheet 2');
         });
 
-        it('should build correct structure with workbook section', () => {
+        it('should build structure with exactly one workbook section', () => {
             initializeWorkbook(FRONTMATTER_ONLY, DEFAULT_CONFIG);
             const state = JSON.parse(getState());
 
-            // Structure should contain the workbook
-            expect(state.structure).not.toBeNull();
-            const wbSections = state.structure.filter((s: { type: string }) => s.type === 'workbook');
-            expect(wbSections.length).toBe(1);
+            // Strict: structure contains exactly one workbook section
+            const wbSections = state.structure.filter(
+                (s: { type: string }) => s.type === 'workbook'
+            );
+            expect(wbSections).toHaveLength(1);
+            // No document sections expected (no H1 = no separate docs)
+            const docSections = state.structure.filter(
+                (s: { type: string }) => s.type === 'document'
+            );
+            expect(docSections).toHaveLength(0);
         });
 
-        it('should build correct tab_order with sheets', () => {
+        it('should build tab_order with correct sheet entries', () => {
             initializeWorkbook(FRONTMATTER_ONLY, DEFAULT_CONFIG);
             const state = JSON.parse(getState());
 
-            // tab_order should include sheets
             const tabOrder = state.workbook.metadata?.tab_order;
-            expect(tabOrder).toBeDefined();
-
-            const sheetTabs = tabOrder.filter((t: { type: string }) => t.type === 'sheet');
-            expect(sheetTabs.length).toBe(2);
+            // Strict: tab_order exists and has correct structure
+            expect(tabOrder).toBeInstanceOf(Array);
+            const sheetTabs = tabOrder.filter(
+                (t: { type: string }) => t.type === 'sheet'
+            );
+            expect(sheetTabs).toHaveLength(2);
+            // Verify indices are correct
+            expect(sheetTabs[0].index).toBe(0);
+            expect(sheetTabs[1].index).toBe(1);
         });
 
-        it('should update cell in-place, not append at EOF', () => {
+        it('should update cell in-place with startLine=0 (not append at EOF)', () => {
             initializeWorkbook(FRONTMATTER_ONLY, DEFAULT_CONFIG);
 
-            // Update a cell and verify the result replaces correctly
             const result = updateCell(0, 0, 0, 0, 'Changed');
 
+            // No error
             expect(result.error).toBeUndefined();
-            expect(result.content).toBeDefined();
-            // startLine should be 0 (virtual root), not lines.length (append)
+            // Virtual root starts at line 0
             expect(result.startLine).toBe(0);
-            // Content should not be duplicated
-            const occurrences = (result.content!.match(/## Sheet 1/g) || []).length;
-            expect(occurrences).toBe(1);
+            // Content contains the updated value
+            expect(result.content).toContain('Changed');
+            // No duplication: Sheet 1 appears exactly once
+            expect((result.content!.match(/## Sheet 1/g) || []).length).toBe(1);
+            // Sheet 2 also appears exactly once
+            expect((result.content!.match(/## Sheet 2/g) || []).length).toBe(1);
         });
 
-        it('should replace entire file for frontmatter workbook with doc sheets', () => {
-            // Real frontmatter_workbook.md content with metadata and doc sheet
+        it('should replace entire file for workbook with doc sheets and metadata', () => {
+            // Realistic frontmatter_workbook.md: metadata comment + doc sheet
             const realMd = `---
 id: root
 title: root
@@ -119,21 +133,29 @@ This is the root doc.
 
             const result = updateCell(0, 0, 0, 2, 'NEW');
 
+            // No error
             expect(result.error).toBeUndefined();
-            expect(result.content).toBeDefined();
+            // Replacement starts at line 0 (virtual root)
             expect(result.startLine).toBe(0);
 
-            // endLine should cover the entire file (not stop at parser's partial endLine)
+            // endLine covers the entire file
             const totalInputLines = realMd.split('\n').length;
             expect(result.endLine).toBeGreaterThanOrEqual(totalInputLines - 2);
 
-            // No duplication: each section should appear exactly once
+            // No content duplication (each section exactly once)
             expect((result.content!.match(/## Sheet 1/g) || []).length).toBe(1);
             expect((result.content!.match(/## Document 1/g) || []).length).toBe(1);
             expect((result.content!.match(/### MyTable/g) || []).length).toBe(1);
 
-            // Updated value should be in content
+            // Updated value is present
             expect(result.content).toContain('NEW');
+
+            // Frontmatter is preserved in output
+            expect(result.content).toContain('title: root');
+            expect(result.content).toContain('id: root');
+
+            // Root content is preserved
+            expect(result.content).toContain('This is the root doc.');
         });
     });
 
@@ -154,23 +176,31 @@ Journal body content here.
 | 1 | 2 |
 `;
 
-        it('should use H1 as workbook (not frontmatter title)', () => {
+        it('should use H1 as workbook name, not frontmatter title', () => {
             initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
             const state = JSON.parse(getState());
 
-            expect(state.workbook).not.toBeNull();
-            // H1 "Tables" should be the workbook, not frontmatter title
+            // H1 "Tables" takes precedence over frontmatter "My Daily Journal"
             expect(state.workbook.name).toBe('Tables');
-            expect(state.workbook.sheets.length).toBe(1);
+            // Exactly one sheet
+            expect(state.workbook.sheets).toHaveLength(1);
+            expect(state.workbook.sheets[0].name).toBe('Sheet 1');
         });
 
-        it('should detect frontmatter as document section', () => {
+        it('should update cell correctly with H1-based workbook range', () => {
             initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
-            const state = JSON.parse(getState());
 
-            // The frontmatter title doesn't appear as a workbook section
-            // since H1 takes precedence (parser v1.4.2 behavior)
-            expect(state.workbook.name).toBe('Tables');
+            const result = updateCell(0, 0, 0, 0, 'Updated');
+
+            expect(result.error).toBeUndefined();
+            // Content should contain the updated value
+            expect(result.content).toContain('Updated');
+            // No duplication
+            expect((result.content!.match(/## Sheet 1/g) || []).length).toBe(1);
+
+            // Frontmatter content should NOT be in the workbook replacement
+            // (it's before the H1 boundary)
+            expect(result.content).not.toContain('Journal body content here.');
         });
     });
 });

--- a/webview-ui/tests/editor/frontmatter-workbook.test.ts
+++ b/webview-ui/tests/editor/frontmatter-workbook.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { initializeWorkbook, getState, resetContext } from '../../../src/editor';
+import { initializeWorkbook, getState, resetContext, updateCell } from '../../../src/editor';
 
 const DEFAULT_CONFIG = JSON.stringify({});
 
@@ -73,6 +73,67 @@ date: 2024-01-01
 
             const sheetTabs = tabOrder.filter((t: { type: string }) => t.type === 'sheet');
             expect(sheetTabs.length).toBe(2);
+        });
+
+        it('should update cell in-place, not append at EOF', () => {
+            initializeWorkbook(FRONTMATTER_ONLY, DEFAULT_CONFIG);
+
+            // Update a cell and verify the result replaces correctly
+            const result = updateCell(0, 0, 0, 0, 'Changed');
+
+            expect(result.error).toBeUndefined();
+            expect(result.content).toBeDefined();
+            // startLine should be 0 (virtual root), not lines.length (append)
+            expect(result.startLine).toBe(0);
+            // Content should not be duplicated
+            const occurrences = (result.content!.match(/## Sheet 1/g) || []).length;
+            expect(occurrences).toBe(1);
+        });
+
+        it('should replace entire file for frontmatter workbook with doc sheets', () => {
+            // Real frontmatter_workbook.md content with metadata and doc sheet
+            const realMd = `---
+id: root
+title: root
+desc: ""
+updated: 1605266684036
+created: 1595961348801
+---
+
+This is the root doc.
+
+## Sheet 1
+
+### MyTable
+
+| Column 1 | Column 2 | Column 3 |
+| --- | --- | --- |
+|  | 200 |  |
+
+<!-- md-spreadsheet-sheet-metadata: {"layout": {"type": "pane", "id": "root", "tables": [0], "activeTableIndex": 0}} -->
+
+## Document 1
+
+`;
+            initializeWorkbook(realMd, DEFAULT_CONFIG);
+
+            const result = updateCell(0, 0, 0, 2, 'NEW');
+
+            expect(result.error).toBeUndefined();
+            expect(result.content).toBeDefined();
+            expect(result.startLine).toBe(0);
+
+            // endLine should cover the entire file (not stop at parser's partial endLine)
+            const totalInputLines = realMd.split('\n').length;
+            expect(result.endLine).toBeGreaterThanOrEqual(totalInputLines - 2);
+
+            // No duplication: each section should appear exactly once
+            expect((result.content!.match(/## Sheet 1/g) || []).length).toBe(1);
+            expect((result.content!.match(/## Document 1/g) || []).length).toBe(1);
+            expect((result.content!.match(/### MyTable/g) || []).length).toBe(1);
+
+            // Updated value should be in content
+            expect(result.content).toContain('NEW');
         });
     });
 

--- a/webview-ui/tests/editor/frontmatter-workbook.test.ts
+++ b/webview-ui/tests/editor/frontmatter-workbook.test.ts
@@ -60,14 +60,10 @@ date: 2024-01-01
             const state = JSON.parse(getState());
 
             // Strict: structure contains exactly one workbook section
-            const wbSections = state.structure.filter(
-                (s: { type: string }) => s.type === 'workbook'
-            );
+            const wbSections = state.structure.filter((s: { type: string }) => s.type === 'workbook');
             expect(wbSections).toHaveLength(1);
             // No document sections expected (no H1 = no separate docs)
-            const docSections = state.structure.filter(
-                (s: { type: string }) => s.type === 'document'
-            );
+            const docSections = state.structure.filter((s: { type: string }) => s.type === 'document');
             expect(docSections).toHaveLength(0);
         });
 
@@ -78,9 +74,7 @@ date: 2024-01-01
             const tabOrder = state.workbook.metadata?.tab_order;
             // Strict: tab_order exists and has correct structure
             expect(tabOrder).toBeInstanceOf(Array);
-            const sheetTabs = tabOrder.filter(
-                (t: { type: string }) => t.type === 'sheet'
-            );
+            const sheetTabs = tabOrder.filter((t: { type: string }) => t.type === 'sheet');
             expect(sheetTabs).toHaveLength(2);
             // Verify indices are correct
             expect(sheetTabs[0].index).toBe(0);
@@ -192,7 +186,7 @@ This is the root doc.
             expect(result.error).toBeUndefined();
 
             const lines = result.content!.split('\n');
-            const docHeaderIdx = lines.findIndex(l => l === '## Document 1');
+            const docHeaderIdx = lines.findIndex((l) => l === '## Document 1');
             // Document 1 header must be present
             expect(docHeaderIdx).toBeGreaterThan(-1);
 
@@ -250,7 +244,7 @@ test
             expect(result2.error).toBeUndefined();
 
             const lines = result2.content!.split('\n');
-            const docHeaderIdx = lines.findIndex(l => l === '## Document 1');
+            const docHeaderIdx = lines.findIndex((l) => l === '## Document 1');
             expect(docHeaderIdx).toBeGreaterThan(-1);
 
             // Count blank lines after Document 1 header

--- a/webview-ui/tests/editor/frontmatter-workbook.test.ts
+++ b/webview-ui/tests/editor/frontmatter-workbook.test.ts
@@ -157,6 +157,117 @@ This is the root doc.
             // Root content is preserved
             expect(result.content).toContain('This is the root doc.');
         });
+
+        it('should NOT insert extra blank lines under doc sheet header after cell edit', () => {
+            // Blueprint: Editing cell 0,0 in Sheet 1 should regenerate the markdown
+            // without adding extra blank lines between "## Document 1" and its content.
+            // Bug: generateAndGetRange was inserting an extra newline before doc sheet content.
+            const realMd = `---
+id: root
+title: root
+desc: ""
+updated: 1605266684036
+created: 1595961348801
+---
+
+This is the root doc.
+
+## Sheet 1
+
+### MyTable
+
+| Column 1 | Column 2 | Column 3 |
+| --- | --- | --- |
+|  | 200 |  |
+
+<!-- md-spreadsheet-sheet-metadata: {"layout": {"type": "pane", "id": "root", "tables": [0], "activeTableIndex": 0}} -->
+
+## Document 1
+
+`;
+            initializeWorkbook(realMd, DEFAULT_CONFIG);
+
+            const result = updateCell(0, 0, 0, 0, 'test');
+
+            expect(result.error).toBeUndefined();
+
+            const lines = result.content!.split('\n');
+            const docHeaderIdx = lines.findIndex(l => l === '## Document 1');
+            // Document 1 header must be present
+            expect(docHeaderIdx).toBeGreaterThan(-1);
+
+            // Count consecutive blank lines immediately after "## Document 1"
+            let blankCount = 0;
+            for (let i = docHeaderIdx + 1; i < lines.length; i++) {
+                if (lines[i] === '') blankCount++;
+                else break;
+            }
+
+            // At most 1 blank line after header (standard markdown paragraph spacing)
+            // Bug produces 2+ blank lines
+            expect(blankCount).toBeLessThanOrEqual(1);
+        });
+
+        it('should NOT accumulate blank lines on repeated cell edits', () => {
+            // Blueprint: Multiple sequential edits should not keep adding blank lines.
+            // Each edit regenerates the full file, so blank lines should remain stable.
+            const realMd = `---
+id: root
+title: root
+desc: ""
+updated: 1605266684036
+created: 1595961348801
+---
+
+This is the root doc.
+
+## Sheet 1
+
+### MyTable
+
+| Column 1 | Column 2 | Column 3 |
+| --- | --- | --- |
+|  | 200 |  |
+
+<!-- md-spreadsheet-sheet-metadata: {"layout": {"type": "pane", "id": "root", "tables": [0], "activeTableIndex": 0}} -->
+
+## Document 1
+
+test
+`;
+            initializeWorkbook(realMd, DEFAULT_CONFIG);
+
+            // Edit #1
+            const result1 = updateCell(0, 0, 0, 0, 'edit1');
+            expect(result1.error).toBeUndefined();
+
+            // Re-initialize with the output of edit #1 (simulates persisted file)
+            resetContext();
+            initializeWorkbook(result1.content!, DEFAULT_CONFIG);
+
+            // Edit #2
+            const result2 = updateCell(0, 0, 0, 0, 'edit2');
+            expect(result2.error).toBeUndefined();
+
+            const lines = result2.content!.split('\n');
+            const docHeaderIdx = lines.findIndex(l => l === '## Document 1');
+            expect(docHeaderIdx).toBeGreaterThan(-1);
+
+            // Count blank lines after Document 1 header
+            let blankCount = 0;
+            for (let i = docHeaderIdx + 1; i < lines.length; i++) {
+                if (lines[i] === '') blankCount++;
+                else break;
+            }
+
+            // Should still be at most 1 blank line, NOT accumulating
+            expect(blankCount).toBeLessThanOrEqual(1);
+
+            // "test" content should still be present (doc sheet body preserved)
+            expect(result2.content).toContain('test');
+            // No duplication
+            expect((result2.content!.match(/## Document 1/g) || []).length).toBe(1);
+        });
     });
 
     describe('Scenario B: Frontmatter + H1 headers', () => {

--- a/webview-ui/tests/editor/frontmatter-workbook.test.ts
+++ b/webview-ui/tests/editor/frontmatter-workbook.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Frontmatter Workbook Tests
+ *
+ * Tests for loading and operating on workbooks that use YAML frontmatter
+ * as the workbook root (virtual root) instead of an explicit H1 header.
+ *
+ * Scenario A: Frontmatter title only (no H1 headers)
+ *   → Parser treats frontmatter as workbook root
+ *   → Editor must handle virtual root (rootMarker not in text)
+ *
+ * Scenario B: Frontmatter title + H1 headers
+ *   → Parser treats H1 as workbook root, frontmatter as Document section
+ *   → Editor works normally (H1 is in text)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initializeWorkbook, getState, resetContext } from '../../../src/editor';
+
+const DEFAULT_CONFIG = JSON.stringify({});
+
+describe('Frontmatter Workbook Tests', () => {
+    beforeEach(() => {
+        resetContext();
+    });
+
+    describe('Scenario A: Frontmatter-only workbook (no H1)', () => {
+        const FRONTMATTER_ONLY = `---
+title: My Daily Journal
+date: 2024-01-01
+---
+
+## Sheet 1
+
+| A | B |
+|---|---|
+| 1 | 2 |
+
+## Sheet 2
+
+| C |
+|---|
+| 3 |
+`;
+
+        it('should parse frontmatter workbook and detect sheets', () => {
+            initializeWorkbook(FRONTMATTER_ONLY, DEFAULT_CONFIG);
+            const state = JSON.parse(getState());
+
+            expect(state.workbook).not.toBeNull();
+            expect(state.workbook.name).toBe('My Daily Journal');
+            expect(state.workbook.sheets.length).toBe(2);
+            expect(state.workbook.sheets[0].name).toBe('Sheet 1');
+            expect(state.workbook.sheets[1].name).toBe('Sheet 2');
+        });
+
+        it('should build correct structure with workbook section', () => {
+            initializeWorkbook(FRONTMATTER_ONLY, DEFAULT_CONFIG);
+            const state = JSON.parse(getState());
+
+            // Structure should contain the workbook
+            expect(state.structure).not.toBeNull();
+            const wbSections = state.structure.filter((s: { type: string }) => s.type === 'workbook');
+            expect(wbSections.length).toBe(1);
+        });
+
+        it('should build correct tab_order with sheets', () => {
+            initializeWorkbook(FRONTMATTER_ONLY, DEFAULT_CONFIG);
+            const state = JSON.parse(getState());
+
+            // tab_order should include sheets
+            const tabOrder = state.workbook.metadata?.tab_order;
+            expect(tabOrder).toBeDefined();
+
+            const sheetTabs = tabOrder.filter((t: { type: string }) => t.type === 'sheet');
+            expect(sheetTabs.length).toBe(2);
+        });
+    });
+
+    describe('Scenario B: Frontmatter + H1 headers', () => {
+        const FRONTMATTER_WITH_H1 = `---
+title: My Daily Journal
+date: 2024-01-01
+---
+
+Journal body content here.
+
+# Tables
+
+## Sheet 1
+
+| A | B |
+|---|---|
+| 1 | 2 |
+`;
+
+        it('should use H1 as workbook (not frontmatter title)', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+            const state = JSON.parse(getState());
+
+            expect(state.workbook).not.toBeNull();
+            // H1 "Tables" should be the workbook, not frontmatter title
+            expect(state.workbook.name).toBe('Tables');
+            expect(state.workbook.sheets.length).toBe(1);
+        });
+
+        it('should detect frontmatter as document section', () => {
+            initializeWorkbook(FRONTMATTER_WITH_H1, DEFAULT_CONFIG);
+            const state = JSON.parse(getState());
+
+            // The frontmatter title doesn't appear as a workbook section
+            // since H1 takes precedence (parser v1.4.2 behavior)
+            expect(state.workbook.name).toBe('Tables');
+        });
+    });
+});

--- a/webview-ui/tests/regression/i18n-tab-names.test.ts
+++ b/webview-ui/tests/regression/i18n-tab-names.test.ts
@@ -381,4 +381,202 @@ Some content
             expect(tableNames).not.toContain('Table 1');
         });
     });
+
+    describe('bug: sheet counter should not count doc sheets (integration)', () => {
+        it('1 sheet + 1 doc sheet: addSheet should create "Sheet 2", not "Sheet 3"', () => {
+            const md = `# Doc
+
+## Sheet 1
+
+### Table 1
+
+| A |
+|---|
+| 1 |
+
+## Document 1
+
+Some text content
+`;
+            editor.initializeWorkbook(md, JSON.stringify({}));
+            setLanguage('en');
+
+            // Verify initial state: 1 spreadsheet + 1 doc sheet
+            const stateBefore = JSON.parse(editor.getState());
+            const sheetsBefore = stateBefore.workbook.sheets as { name: string; tables: unknown[] }[];
+            expect(sheetsBefore).toHaveLength(2); // Sheet 1 + Document 1
+            expect(sheetsBefore[0].name).toBe('Sheet 1');
+            expect(sheetsBefore[0].tables).toHaveLength(1); // spreadsheet
+            expect(sheetsBefore[1].name).toBe('Document 1');
+            expect(sheetsBefore[1].tables).toHaveLength(0); // doc sheet
+
+            // Integration: addSheet via editor API — name should be based on spreadsheet count only
+            const result = editor.addSheet('Sheet 2', ['Col 1'], 'Table 1', null, null);
+            expect(result.error).toBeUndefined();
+
+            const stateAfter = JSON.parse(editor.getState());
+            const sheetsAfter = stateAfter.workbook.sheets as { name: string }[];
+            const sheetNames = sheetsAfter.map((s) => s.name);
+
+            // Sheet 2 should exist (counter based on 1 spreadsheet, not 2 total sheets)
+            expect(sheetNames).toContain('Sheet 2');
+            // Sheet 3 should NOT exist (would happen if doc sheets were counted)
+            expect(sheetNames).not.toContain('Sheet 3');
+        });
+
+        it('2 sheets + 2 doc sheets: third addSheet should create "Sheet 3"', () => {
+            const md = `# Doc
+
+## Sheet 1
+
+### Table 1
+
+| A |
+|---|
+| 1 |
+
+## Document 1
+
+Some doc content
+
+## Sheet 2
+
+### Table 2
+
+| B |
+|---|
+| 2 |
+
+## Document 2
+
+More doc content
+`;
+            editor.initializeWorkbook(md, JSON.stringify({}));
+            setLanguage('en');
+
+            // Verify initial state: 2 spreadsheets + 2 doc sheets = 4 sheets total
+            const stateBefore = JSON.parse(editor.getState());
+            const sheetsBefore = stateBefore.workbook.sheets as { name: string; tables: unknown[] }[];
+            expect(sheetsBefore).toHaveLength(4);
+
+            const spreadsheetCount = sheetsBefore.filter((s) => s.tables && s.tables.length > 0).length;
+            const docSheetCount = sheetsBefore.filter((s) => !s.tables || s.tables.length === 0).length;
+            expect(spreadsheetCount).toBe(2); // Sheet 1, Sheet 2
+            expect(docSheetCount).toBe(2);    // Document 1, Document 2
+
+            // Integration: addSheet — counter should be 3 (2 spreadsheets + 1), NOT 5 (4 total + 1)
+            const result = editor.addSheet('Sheet 3', ['Col 1'], 'Table 1', null, null);
+            expect(result.error).toBeUndefined();
+
+            const stateAfter = JSON.parse(editor.getState());
+            const sheetNames = stateAfter.workbook.sheets.map((s: { name: string }) => s.name);
+            expect(sheetNames).toContain('Sheet 3');
+            expect(sheetNames).not.toContain('Sheet 5');
+        });
+    });
+
+    describe('bug: doc counter should not count pinned frontmatter tab (integration)', () => {
+        it('workbook with no docs: addDocSheet should create "Document 1"', () => {
+            const md = `# Doc
+
+## Sheet 1
+
+### Table 1
+
+| A |
+|---|
+| 1 |
+`;
+            editor.initializeWorkbook(md, JSON.stringify({}));
+            setLanguage('en');
+
+            // Verify initial state: 1 spreadsheet, 0 doc sheets
+            const stateBefore = JSON.parse(editor.getState());
+            const sheetsBefore = stateBefore.workbook.sheets as { name: string }[];
+            expect(sheetsBefore).toHaveLength(1);
+            expect(sheetsBefore[0].name).toBe('Sheet 1');
+
+            // Integration: addDocSheet — should be "Document 1" (no docs exist)
+            const result = editor.addDocSheet('Document 1', '', null, null);
+            expect(result.error).toBeUndefined();
+
+            const stateAfter = JSON.parse(editor.getState());
+            const names = stateAfter.workbook.sheets.map((s: { name: string }) => s.name);
+            expect(names).toContain('Document 1');
+        });
+
+        it('sequential doc adds: should produce "Document 1", "Document 2", "Document 3"', () => {
+            const md = `# Doc
+
+## Sheet 1
+
+### Table 1
+
+| A |
+|---|
+| 1 |
+`;
+            editor.initializeWorkbook(md, JSON.stringify({}));
+            setLanguage('en');
+
+            // Add first doc
+            const result1 = editor.addDocSheet('Document 1', '', null, null);
+            expect(result1.error).toBeUndefined();
+
+            // Add second doc
+            const result2 = editor.addDocSheet('Document 2', '', null, null);
+            expect(result2.error).toBeUndefined();
+
+            // Add third doc
+            const result3 = editor.addDocSheet('Document 3', '', null, null);
+            expect(result3.error).toBeUndefined();
+
+            // Verify all three docs exist with correct sequential names
+            const stateAfter = JSON.parse(editor.getState());
+            const names = stateAfter.workbook.sheets.map((s: { name: string }) => s.name);
+            expect(names).toContain('Document 1');
+            expect(names).toContain('Document 2');
+            expect(names).toContain('Document 3');
+            expect(names).toHaveLength(4); // Sheet 1 + 3 docs
+        });
+
+        it('1 existing doc sheet: next addDocSheet should create "Document 2", not duplicate', () => {
+            const md = `# Doc
+
+## Sheet 1
+
+### Table 1
+
+| A |
+|---|
+| 1 |
+
+## Document 1
+
+Existing doc content
+`;
+            editor.initializeWorkbook(md, JSON.stringify({}));
+            setLanguage('en');
+
+            // Verify "Document 1" already exists as a doc sheet
+            const stateBefore = JSON.parse(editor.getState());
+            const sheetsBefore = stateBefore.workbook.sheets as { name: string; tables: unknown[] }[];
+            const docSheetsBefore = sheetsBefore.filter((s) => !s.tables || s.tables.length === 0);
+            expect(docSheetsBefore).toHaveLength(1);
+            expect(docSheetsBefore[0].name).toBe('Document 1');
+
+            // Integration: addDocSheet — should be "Document 2", NOT another "Document 1"
+            const result = editor.addDocSheet('Document 2', '', null, null);
+            expect(result.error).toBeUndefined();
+
+            const stateAfter = JSON.parse(editor.getState());
+            const names = stateAfter.workbook.sheets.map((s: { name: string }) => s.name);
+
+            // Verify correct name and no duplicates
+            expect(names).toContain('Document 2');
+            const doc1Count = names.filter((n: string) => n === 'Document 1').length;
+            expect(doc1Count).toBe(1); // Only one "Document 1" — no duplication
+        });
+    });
 });
+

--- a/webview-ui/tests/regression/i18n-tab-names.test.ts
+++ b/webview-ui/tests/regression/i18n-tab-names.test.ts
@@ -462,7 +462,7 @@ More doc content
             const spreadsheetCount = sheetsBefore.filter((s) => s.tables && s.tables.length > 0).length;
             const docSheetCount = sheetsBefore.filter((s) => !s.tables || s.tables.length === 0).length;
             expect(spreadsheetCount).toBe(2); // Sheet 1, Sheet 2
-            expect(docSheetCount).toBe(2);    // Document 1, Document 2
+            expect(docSheetCount).toBe(2); // Document 1, Document 2
 
             // Integration: addSheet — counter should be 3 (2 spreadsheets + 1), NOT 5 (4 total + 1)
             const result = editor.addSheet('Sheet 3', ['Col 1'], 'Table 1', null, null);
@@ -579,4 +579,3 @@ Existing doc content
         });
     });
 });
-

--- a/webview-ui/types.ts
+++ b/webview-ui/types.ts
@@ -103,10 +103,12 @@ export interface TabDefinition {
     sheetIndex?: number;
     docIndex?: number; // Document section index for document tabs
     data?: SheetJSON | DocumentJSON | unknown;
+    /** Pinned tabs are immovable (not draggable). Used for root and frontmatter tabs. */
+    pinned?: boolean;
 }
 
 export interface StructureItem {
-    type: 'workbook' | 'document';
+    type: 'workbook' | 'document' | 'frontmatter';
     title?: string;
     content?: string;
 }


### PR DESCRIPTION
## Summary

Add support for Markdown files containing YAML frontmatter.

### Scenario A: Frontmatter only (no H1 headers)
- Frontmatter `title` is used as the workbook name (virtual root)
- The entire file is treated as the workbook scope

### Scenario B: Frontmatter + H1 headers
- H1 header takes precedence as workbook root
- Frontmatter section becomes a **pinned (immovable) Document tab** at position 0
- Shares the same immovable mechanism as the Overview (root) tab

## Changes

### New
- `js-yaml` dependency for YAML frontmatter parsing
- `extractFrontmatter()` function in `structure.ts`
- `FrontmatterSection` type in `types.ts`
- `TabDefinition.pinned` flag for immovable tabs
- Frontmatter tests (`frontmatter-tab.test.ts`, `frontmatter-workbook.test.ts`)
- Sample files (`frontmatter_workbook.md`, `frontmatter_multi_header.md`)

### Fixed
- Virtual root workbook saves appending content at EOF instead of replacing in-place
- YAML frontmatter block hidden from Document tab content (matches VS Code standard markdown preview behavior)

## Test Results
1069/1069 tests pass ✅

Closes #5