### PR TITLE
release: v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "PengSheets" extension will be documented in this fil
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-03-11
+
 ### Added
 - Support YAML frontmatter with `title` field as an H1 equivalent, following a widely adopted convention.
 - Display a read-only header field above the editor in Document tab edit mode, showing the Markdown heading level (e.g. `## Title`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "peng-sheets",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "peng-sheets",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "dependencies": {
                 "js-yaml": "^4.1.1",
                 "md-spreadsheet-parser": "^1.4.3"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "displayName": "PengSheets - Markdown Spreadsheet Editor",
     "description": "Transform Markdown tables into a powerful spreadsheet editor with Excel-like editing, multi-sheet workbooks, and real-time synchronization.",
     "icon": "images/icon.png",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "engines": {
         "vscode": "^1.90.0"
     },


### PR DESCRIPTION
Release v1.3.0

### Added
- Support YAML frontmatter with `title` field as an H1 equivalent
- Display a read-only header field above the editor in Document tab edit mode
- Frontmatter tab now supports editing, renaming, and deletion via context menu

### Fixed
- Fix empty table cells containing extra whitespace
- Fix extra blank lines accumulating under Document tab headers
- Fix "Document tab missing docIndex" error when editing frontmatter tabs
- Fix blank line preservation between frontmatter body and H1 header