### PR TITLE
release: v1.4.0

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -43,8 +43,23 @@ node_modules/md-spreadsheet-parser/dist/*.wasm
 # Exclude test/build caches
 .pytest_cache/**
 
+# Exclude development docs
+docs/**
+
 # Exclude source files from node_modules
 node_modules/md-spreadsheet-parser/src/**
+
+# Exclude Vite-bundled dependencies (already in out/webview/main.js)
+node_modules/easymde/**
+node_modules/codemirror/**
+node_modules/codemirror-spell-checker/**
+node_modules/typo-js/**
+node_modules/highlight.js/**
+node_modules/marked/**
+node_modules/marked-highlight/**
+node_modules/js-yaml/**
+node_modules/argparse/**
+node_modules/onetime/**
 
 # Exclude devDependencies (only md-spreadsheet-parser and @bytecodealliance are needed at runtime)
 node_modules/@nodelib/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "PengSheets" extension will be documented in this fil
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-04-11
+
 ### Added
 
 - Native image support in Document tabs with paste and drag-and-drop capabilities.

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,6 +24,10 @@
 </p>
 
 <p align="center">
+  | <a href="https://github.com/f-y/peng-sheets/blob/main/README.md">English</a> | 日本語 |
+</p>
+
+<p align="center">
   <a href="#-特徴">特徴</a> •
   <a href="#-クイックスタート">クイックスタート</a> •
   <a href="#-なぜpengsheets">PengSheetsの利点</a> •

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
 </p>
 
 <p align="center">
+  | English | <a href="https://github.com/f-y/peng-sheets/blob/main/README.ja.md">日本語</a> |
+</p>
+
+<p align="center">
   <a href="#-highlights">Highlights</a> •
   <a href="#-quick-start">Quick Start</a> •
   <a href="#-why-pengsheets">Why PengSheets</a> •
@@ -45,8 +49,6 @@ With **Formula Columns**, you can reference values from other tables by key, jus
 </p>
 
 **PengSheets** transforms your Markdown tables into a rich, interactive spreadsheet view. Powered by [md-spreadsheet-parser](https://github.com/f-y/md-spreadsheet-parser), it runs a robust Python parser directly in your editor via WebAssembly, offering superior parsing accuracy and seamless multi-sheet support.
-
-> Read in Japanese: 日本語版はこちら（ <a href="https://github.com/f-y/peng-sheets/blob/main/README.ja.md">README</a> ）
 
 ## ✨ Highlights
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "peng-sheets",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "peng-sheets",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "dependencies": {
                 "easymde": "^2.20.0",
                 "highlight.js": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "displayName": "PengSheets - Markdown Spreadsheet Editor",
     "description": "Transform Markdown tables into a powerful spreadsheet editor with Excel-like editing, multi-sheet workbooks, and real-time synchronization.",
     "icon": "images/icon.png",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "engines": {
         "vscode": "^1.90.0"
     },
@@ -97,28 +97,36 @@
                 "key": "ctrl+b",
                 "mac": "cmd+b",
                 "command": "peng-sheets.editorAction",
-                "args": { "action": "bold" },
+                "args": {
+                    "action": "bold"
+                },
                 "when": "activeCustomEditorId == 'peng-sheets.editor'"
             },
             {
                 "key": "ctrl+i",
                 "mac": "cmd+i",
                 "command": "peng-sheets.editorAction",
-                "args": { "action": "italic" },
+                "args": {
+                    "action": "italic"
+                },
                 "when": "activeCustomEditorId == 'peng-sheets.editor'"
             },
             {
                 "key": "ctrl+h",
                 "mac": "cmd+h",
                 "command": "peng-sheets.editorAction",
-                "args": { "action": "heading" },
+                "args": {
+                    "action": "heading"
+                },
                 "when": "activeCustomEditorId == 'peng-sheets.editor'"
             },
             {
                 "key": "ctrl+k",
                 "mac": "cmd+k",
                 "command": "peng-sheets.editorAction",
-                "args": { "action": "link" },
+                "args": {
+                    "action": "link"
+                },
                 "when": "activeCustomEditorId == 'peng-sheets.editor'"
             },
             {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "peng-sheets",
     "publisher": "f-y",
     "displayName": "PengSheets - Markdown Spreadsheet Editor",
-    "description": "Transform Markdown tables into a powerful spreadsheet editor with Excel-like editing, multi-sheet workbooks, and real-time synchronization.",
+    "description": "Excel-like Markdown table editor — multi-sheet workbooks, cross-table lookups, and live sync.",
     "icon": "images/icon.png",
     "version": "1.4.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Bump version to 1.4.0 and update CHANGELOG with Unreleased entries
  (image support, image paste in cells, EasyMDE integration)
- Exclude Vite-bundled dependencies from VSIX package (20.91 MB → 16.69 MB, 2427 → 407 files)
- Replace language link with `| English | 日本語 |` switcher bar in READMEs
- Rewrite extension description for better marketplace visibility

## Test plan

- [x] `npm test` — 27 passing
- [x] `npm run test:webview` — 1187 tests passing
- [x] `vsce package` — builds successfully (16.69 MB)