### PR TITLE
fix(webview): cursor movement in column header edit mode (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the "PengSheets" extension will be documented in this fil
 
 - Fix Backspace / Delete / character insertion in cell edit mode ignoring caret position and operating on the end of the text. Edits now respect the current cursor position in both data cells and column headers. (#14)
 - Fix spreadsheet changes sometimes not appearing until saving, including adding tabs, pasting cells, and adding columns.
+- Fix cursor movement while editing column names. Arrow keys and clicks inside the edited header now move the text cursor without leaving edit mode. (#15)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the "PengSheets" extension will be documented in this fil
 ### Changed
 
 - Remove the obsolete "Click to edit" hint shown in empty Document tabs. The hint referenced an interaction that no longer exists and was misleading.
+- Show a table icon on editor tabs opened with PengSheets, making them easier to distinguish from plain Markdown tabs.
 
 ## [1.4.0] - 2026-04-11
 

--- a/src/spreadsheet-editor-provider.ts
+++ b/src/spreadsheet-editor-provider.ts
@@ -49,6 +49,8 @@ export class SpreadsheetEditorProvider implements vscode.CustomTextEditorProvide
         webviewPanel: vscode.WebviewPanel,
         _token: vscode.CancellationToken
     ): Promise<void> {
+        webviewPanel.iconPath = new vscode.ThemeIcon('table');
+
         // Allow the webview to load resources from:
         // 1. Extension's own output directory
         // 2. Extension's resources directory

--- a/webview-ui/controllers/event-controller.ts
+++ b/webview-ui/controllers/event-controller.ts
@@ -226,6 +226,13 @@ export class EventController implements ReactiveController {
     // ============================================================
 
     handleColClick = (e: CustomEvent<{ col: number; shiftKey: boolean }>) => {
+        if (
+            this.host.editCtrl.isEditing &&
+            this.host.selectionCtrl.selectedRow === -1 &&
+            this.host.selectionCtrl.selectedCol === e.detail.col
+        ) {
+            return;
+        }
         this.host.selectionCtrl.selectCell(-2, e.detail.col, e.detail.shiftKey);
         this.host.focusCell();
     };
@@ -233,6 +240,14 @@ export class EventController implements ReactiveController {
     handleColMousedown = (e: CustomEvent<{ col: number; shiftKey: boolean; originalEvent?: MouseEvent }>) => {
         const col = e.detail.col;
         const shiftKey = e.detail.shiftKey;
+
+        if (
+            this.host.editCtrl.isEditing &&
+            this.host.selectionCtrl.selectedRow === -1 &&
+            this.host.selectionCtrl.selectedCol === col
+        ) {
+            return;
+        }
 
         // Check if this column is already in selection (potential drag)
         const { selectedRow, selectedCol, selectionAnchorCol } = this.host.selectionCtrl;
@@ -372,6 +387,14 @@ export class EventController implements ReactiveController {
     };
 
     handleCellClick = async (e: CustomEvent<{ row: number; col: number; shiftKey: boolean }>) => {
+        if (
+            this.host.editCtrl.isEditing &&
+            this.host.selectionCtrl.selectedRow === e.detail.row &&
+            this.host.selectionCtrl.selectedCol === e.detail.col
+        ) {
+            return;
+        }
+
         // Commit current edit if active
         // Logic from _commitCurrentEdit (moved/adapted)
         if (this.host.editCtrl.isEditing) {
@@ -392,6 +415,16 @@ export class EventController implements ReactiveController {
             originalEvent?: MouseEvent;
         }>
     ) => {
+        const { row, col, shiftKey } = e.detail;
+
+        if (
+            this.host.editCtrl.isEditing &&
+            this.host.selectionCtrl.selectedRow === row &&
+            this.host.selectionCtrl.selectedCol === col
+        ) {
+            return;
+        }
+
         // Commit any pending edit before changing selection (click-away commit)
         if (this.host.editCtrl.isEditing) {
             // Editing cell is in View's shadow DOM
@@ -426,8 +459,6 @@ export class EventController implements ReactiveController {
                 this.host.editCtrl.cancelEditing();
             }
         }
-
-        const { row, col, shiftKey } = e.detail;
 
         // Check if this cell is already in selection (potential drag)
         const { selectedRow, selectedCol, selectionAnchorRow, selectionAnchorCol } = this.host.selectionCtrl;

--- a/webview-ui/controllers/keyboard-controller.ts
+++ b/webview-ui/controllers/keyboard-controller.ts
@@ -354,29 +354,30 @@ export class KeyboardController implements ReactiveController {
             // Get the editing cell's text content to determine behavior
             const root = this.host.viewShadowRoot || this.host.shadowRoot;
             const editingCell = root?.querySelector('.cell.editing') as HTMLElement | null;
-            const cellText = editingCell?.textContent || '';
-            const isMultiline = cellText.includes('\n') || editingCell?.querySelector('br') !== null;
+            const editTarget =
+                (editingCell?.querySelector('[contenteditable="true"]') as HTMLElement | null) ?? editingCell;
+            const cellText = editTarget ? getDOMText(editTarget, true) : '';
+            const isHeaderEdit = this.host.selectionCtrl.selectedRow === -1;
+            const isMultiline = cellText.includes('\n') || editTarget?.querySelector('br') !== null;
 
             // ArrowUp/Down in multiline cells: always stay in cell (prevent accidental exit)
             if ((e.key === 'ArrowUp' || e.key === 'ArrowDown') && isMultiline) {
                 return; // Let browser handle
             }
 
-            // Check if cursor is at boundary for committing and navigating
-            const selection = window.getSelection();
-            if (selection && selection.rangeCount > 0) {
-                const range = selection.getRangeAt(0);
-                const isCollapsed = range.collapsed;
+            // Column headers are single-line editable spans. Up/Down should not leave edit mode.
+            if ((e.key === 'ArrowUp' || e.key === 'ArrowDown') && isHeaderEdit) {
+                return; // Let browser keep focus/caret in the header editor
+            }
 
-                if (isCollapsed && editingCell) {
+            // Check if cursor is at boundary for committing and navigating
+            const selection = getEditSelection(root);
+            if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && selection && editTarget) {
+                if (selection.isCollapsed) {
+                    const { start, end } = getCaretOffsetInElement(editTarget, selection);
                     // ArrowLeft at position 0: commit & navigate left
                     if (e.key === 'ArrowLeft') {
-                        const atStart =
-                            range.startOffset === 0 &&
-                            (range.startContainer === editingCell ||
-                                range.startContainer === editingCell.firstChild ||
-                                (range.startContainer.nodeType === Node.TEXT_NODE &&
-                                    range.startContainer === editingCell.childNodes[0]));
+                        const atStart = start === 0;
                         if (!atStart) {
                             return; // Let browser move cursor within text
                         }
@@ -384,19 +385,13 @@ export class KeyboardController implements ReactiveController {
 
                     // ArrowRight at end of text: commit & navigate right
                     if (e.key === 'ArrowRight') {
-                        const lastChild = editingCell.lastChild;
-                        const atEnd =
-                            (range.startContainer === editingCell &&
-                                range.startOffset === editingCell.childNodes.length) ||
-                            (range.startContainer === lastChild &&
-                                range.startOffset === (lastChild.textContent?.length || 0)) ||
-                            (range.startContainer.nodeType === Node.TEXT_NODE &&
-                                range.startOffset === range.startContainer.textContent?.length &&
-                                !range.startContainer.nextSibling);
+                        const atEnd = end === cellText.length;
                         if (!atEnd) {
                             return; // Let browser move cursor within text
                         }
                     }
+                } else if (isHeaderEdit) {
+                    return; // Let browser collapse/adjust the text selection
                 }
             }
 

--- a/webview-ui/tests/components/spreadsheet-table/edit-mode-arrow-navigation.test.ts
+++ b/webview-ui/tests/components/spreadsheet-table/edit-mode-arrow-navigation.test.ts
@@ -3,11 +3,45 @@
  * Arrow keys should commit the current edit and navigate to adjacent cells,
  * similar to Enter/Tab behavior.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { fixture, html } from '@open-wc/testing';
 import '../../../components/spreadsheet-table';
 import { queryView, awaitView } from '../../helpers/test-helpers';
 import { SpreadsheetTable, TableJSON } from '../../../components/spreadsheet-table';
+
+function mockSelectionAt(target: HTMLElement, offset: number): Selection {
+    let textNode: Node | null = null;
+    for (const child of target.childNodes) {
+        if (child.nodeType === Node.TEXT_NODE) {
+            textNode = child;
+            break;
+        }
+    }
+
+    const range = document.createRange();
+    if (textNode) {
+        const clampedOffset = Math.min(offset, textNode.textContent?.length ?? 0);
+        range.setStart(textNode, clampedOffset);
+        range.setEnd(textNode, clampedOffset);
+    } else {
+        range.setStart(target, 0);
+        range.setEnd(target, 0);
+    }
+    range.collapse(true);
+
+    return {
+        rangeCount: 1,
+        getRangeAt: () => range,
+        removeAllRanges: vi.fn(),
+        addRange: vi.fn(),
+        deleteFromDocument: vi.fn(),
+        anchorNode: range.startContainer,
+        anchorOffset: range.startOffset,
+        focusNode: range.endContainer,
+        focusOffset: range.endOffset,
+        isCollapsed: true
+    } as unknown as Selection;
+}
 
 describe('Edit Mode Arrow Key Navigation', () => {
     const createMockTable = (): TableJSON => ({
@@ -94,6 +128,7 @@ describe('Edit Mode Arrow Key Navigation', () => {
 
             // Press ArrowRight
             const editingCell = queryView(el, '.cell.editing') as HTMLElement;
+            const selectionSpy = vi.spyOn(window, 'getSelection').mockReturnValue(mockSelectionAt(editingCell, 1));
             editingCell.dispatchEvent(
                 new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true })
             );
@@ -103,6 +138,7 @@ describe('Edit Mode Arrow Key Navigation', () => {
             expect(el.editCtrl.isEditing).toBe(false);
             expect(el.selectionCtrl.selectedRow).toBe(1);
             expect(el.selectionCtrl.selectedCol).toBe(1);
+            selectionSpy.mockRestore();
         });
     });
 
@@ -177,6 +213,106 @@ describe('Edit Mode Arrow Key Navigation', () => {
             // Should have committed but stay at col 0
             expect(el.editCtrl.isEditing).toBe(false);
             expect(el.selectionCtrl.selectedCol).toBe(0);
+        });
+    });
+
+    describe('Column header edit mode', () => {
+        it('keeps editing when ArrowLeft is pressed in the middle of header text', async () => {
+            const el = await fixture<SpreadsheetTable>(
+                html`<spreadsheet-table .table="${createMockTable()}"></spreadsheet-table>`
+            );
+            await awaitView(el);
+
+            const headerContent = queryView(el, '.cell.header-col[data-col="0"] .cell-content') as HTMLElement;
+            headerContent.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, composed: true }));
+            await awaitView(el);
+
+            const editingContent = queryView(el, '.cell.header-col.editing .cell-content') as HTMLElement;
+            expect(editingContent).toBeTruthy();
+
+            const selectionSpy = vi.spyOn(window, 'getSelection').mockReturnValue(mockSelectionAt(editingContent, 1));
+            editingContent.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, composed: true })
+            );
+            await awaitView(el);
+
+            expect(el.editCtrl.isEditing).toBe(true);
+            expect(el.selectionCtrl.selectedRow).toBe(-1);
+            expect(el.selectionCtrl.selectedCol).toBe(0);
+
+            selectionSpy.mockRestore();
+        });
+
+        it('keeps editing when ArrowUp or ArrowDown is pressed in a header', async () => {
+            const el = await fixture<SpreadsheetTable>(
+                html`<spreadsheet-table .table="${createMockTable()}"></spreadsheet-table>`
+            );
+            await awaitView(el);
+
+            const headerContent = queryView(el, '.cell.header-col[data-col="0"] .cell-content') as HTMLElement;
+            headerContent.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, composed: true }));
+            await awaitView(el);
+
+            const editingContent = queryView(el, '.cell.header-col.editing .cell-content') as HTMLElement;
+            const selectionSpy = vi.spyOn(window, 'getSelection').mockReturnValue(mockSelectionAt(editingContent, 1));
+
+            editingContent.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true })
+            );
+            editingContent.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, composed: true })
+            );
+            await awaitView(el);
+
+            expect(el.editCtrl.isEditing).toBe(true);
+            expect(el.selectionCtrl.selectedRow).toBe(-1);
+            expect(el.selectionCtrl.selectedCol).toBe(0);
+
+            selectionSpy.mockRestore();
+        });
+
+        it('does not override browser caret placement when clicking the edited header', async () => {
+            const el = await fixture<SpreadsheetTable>(
+                html`<spreadsheet-table .table="${createMockTable()}"></spreadsheet-table>`
+            );
+            await awaitView(el);
+
+            const headerContent = queryView(el, '.cell.header-col[data-col="0"] .cell-content') as HTMLElement;
+            headerContent.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, composed: true }));
+            await awaitView(el);
+
+            const focusSpy = vi.spyOn(el, 'focusCell');
+            const editingHeader = queryView(el, '.cell.header-col.editing') as HTMLElement;
+            editingHeader.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
+            editingHeader.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+            await awaitView(el);
+
+            expect(el.editCtrl.isEditing).toBe(true);
+            expect(focusSpy).not.toHaveBeenCalled();
+            focusSpy.mockRestore();
+        });
+    });
+
+    describe('Data cell edit mode click handling', () => {
+        it('does not override browser caret placement when clicking the edited cell', async () => {
+            const el = await fixture<SpreadsheetTable>(
+                html`<spreadsheet-table .table="${createMockTable()}"></spreadsheet-table>`
+            );
+            await awaitView(el);
+
+            const cell = queryView(el, '.cell[data-row="1"][data-col="1"]') as HTMLElement;
+            cell.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, composed: true }));
+            await awaitView(el);
+
+            const focusSpy = vi.spyOn(el, 'focusCell');
+            const editingCell = queryView(el, '.cell.editing') as HTMLElement;
+            editingCell.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
+            editingCell.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+            await awaitView(el);
+
+            expect(el.editCtrl.isEditing).toBe(true);
+            expect(focusSpy).not.toHaveBeenCalled();
+            focusSpy.mockRestore();
         });
     });
 });


### PR DESCRIPTION
## Summary
- Fix arrow keys exiting column-header edit mode: add a single-line "stay in cell" branch for ArrowUp/Down and correct ArrowLeft/Right boundary detection for the two-layer DOM used by `ss-column-header`.
- Fix click handling so a click inside the currently edited header positions the caret instead of leaving edit mode.
- Show a table icon (`ThemeIcon('table')`) on editor tabs opened with PengSheets, making them easier to distinguish from plain Markdown tabs.

Closes #15.

## Test plan
- [x] `npm test` passes
- [x] `npm run test:webview` passes — includes new `edit-mode-arrow-navigation.test.ts` cases
- [x] `npm run lint`
- [x] Manual: double-click a column header, press Arrow keys → caret moves within text, edit mode preserved
- [x] Manual: while editing, click inside the header text → caret moves to click position, edit mode preserved
- [x] Manual: regression — data-cell editing arrow-key behavior unchanged
- [x] Manual: open a `.md` file with PengSheets → editor tab shows a table icon