### PR TITLE
release: v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "PengSheets" extension will be documented in this fil
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-05-19
+
 ### Fixed
 
 - Fix Backspace / Delete / character insertion in cell edit mode ignoring caret position and operating on the end of the text. Edits now respect the current cursor position in both data cells and column headers. (#14)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "peng-sheets",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "peng-sheets",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "dependencies": {
                 "easymde": "^2.20.0",
                 "highlight.js": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "displayName": "PengSheets - Markdown Spreadsheet Editor",
     "description": "Excel-like Markdown table editor — multi-sheet workbooks, cross-table lookups, and live sync.",
     "icon": "images/icon.png",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "engines": {
         "vscode": "^1.90.0"
     },


### PR DESCRIPTION
## Summary

Patch release v1.4.1.

### Fixed
- Fix Backspace / Delete / character insertion in cell edit mode ignoring caret position (#14)
- Fix spreadsheet changes sometimes not appearing until saving (tabs, paste, column add)
- Fix cursor movement while editing column names (#15)

### Changed
- Remove obsolete "Click to edit" hint in empty Document tabs
- Show a table icon on editor tabs opened with PengSheets

## Test plan
- [x] `npm test` — 27 passing
- [x] `npm run test:webview` — 1218 passing
- [x] `npx vsce package` — peng-sheets-1.4.1.vsix (407 files, 16.68 MB)