### PR TITLE
docs: refresh README badges and rewrite extension tagline

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <strong>Excel風Markdownテーブルエディタ — マルチシート複数テーブル、テーブル間ルックアップが可能。作成ファイルはPython/Node.jsからすぐに読込可能。</strong>
+  <strong>PengSheetsはExcel風Markdownテーブルエディタです。マルチシート複数テーブル、テーブル間ルックアップが可能で、作成ファイルはPython/Node.jsからすぐに読み込めます。</strong>
 </p>
 
 <p align="center">

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,21 +5,18 @@
 </p>
 
 <p align="center">
-  <strong>Markdownテーブルを、パワフルなスプレッドシート体験に変える。</strong>
+  <strong>Excel風Markdownテーブルエディタ — マルチシート複数テーブル、テーブル間ルックアップが可能。作成ファイルはPython/Node.jsからすぐに読込可能。</strong>
 </p>
 
 <p align="center">
   <a href="https://open-vsx.org/extension/f-y/peng-sheets">
     <img src="https://img.shields.io/open-vsx/v/f-y/peng-sheets?style=flat-square&label=version" alt="Version">
   </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=f-y.peng-sheets">
-    <img src="https://img.shields.io/visual-studio-marketplace/i/f-y.peng-sheets?style=flat-square&label=VS%20Marketplace" alt="VS Marketplace Installs">
-  </a>
   <a href="https://open-vsx.org/extension/f-y/peng-sheets">
-    <img src="https://img.shields.io/open-vsx/dt/f-y/peng-sheets?style=flat-square&label=Open%20VSX" alt="Open VSX Downloads">
+    <img src="https://img.shields.io/open-vsx/dt/f-y/peng-sheets?style=flat-square&label=Open%20VSX%20downloads" alt="Open VSX Downloads">
   </a>
-  <a href="https://github.com/f-y/peng-sheets/blob/main/LICENSE">
-    <img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License">
+  <a href="https://marketplace.visualstudio.com/items?itemName=f-y.peng-sheets">
+    <img src="https://vsmarketplacebadges.dev/installs-short/f-y.peng-sheets.svg?style=flat-square&label=VS%20Code%20installs" alt="VS Code Installs">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,21 +5,18 @@
 </p>
 
 <p align="center">
-  <strong>Transform your Markdown tables into a powerful spreadsheet experience.</strong>
+  <strong>Excel-like Markdown table editor — multi-sheet workbooks, cross-table lookups. Workbooks load instantly in Python & Node.js scripts.</strong>
 </p>
 
 <p align="center">
   <a href="https://open-vsx.org/extension/f-y/peng-sheets">
     <img src="https://img.shields.io/open-vsx/v/f-y/peng-sheets?style=flat-square&label=version" alt="Version">
   </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=f-y.peng-sheets">
-    <img src="https://img.shields.io/visual-studio-marketplace/i/f-y.peng-sheets?style=flat-square&label=VS%20Marketplace" alt="VS Marketplace Installs">
-  </a>
   <a href="https://open-vsx.org/extension/f-y/peng-sheets">
-    <img src="https://img.shields.io/open-vsx/dt/f-y/peng-sheets?style=flat-square&label=Open%20VSX" alt="Open VSX Downloads">
+    <img src="https://img.shields.io/open-vsx/dt/f-y/peng-sheets?style=flat-square&label=Open%20VSX%20downloads" alt="Open VSX Downloads">
   </a>
-  <a href="https://github.com/f-y/peng-sheets/blob/main/LICENSE">
-    <img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License">
+  <a href="https://marketplace.visualstudio.com/items?itemName=f-y.peng-sheets">
+    <img src="https://vsmarketplacebadges.dev/installs-short/f-y.peng-sheets.svg?style=flat-square&label=VS%20Code%20installs" alt="VS Code Installs">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <strong>Excel-like Markdown table editor — multi-sheet workbooks, cross-table lookups. Workbooks load instantly in Python & Node.js scripts.</strong>
+  <strong>Excel-like Markdown table editor — multi-sheet workbooks, cross-table lookups. Files load instantly from Python & Node.js scripts.</strong>
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "peng-sheets",
     "publisher": "f-y",
     "displayName": "PengSheets - Markdown Spreadsheet Editor",
-    "description": "Excel-like Markdown table editor — multi-sheet workbooks, cross-table lookups. Workbooks load instantly in Python & Node.js scripts.",
+    "description": "Excel-like Markdown table editor — multi-sheet workbooks, cross-table lookups. Files load instantly from Python & Node.js scripts.",
     "icon": "images/icon.png",
     "version": "1.4.1",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "peng-sheets",
     "publisher": "f-y",
     "displayName": "PengSheets - Markdown Spreadsheet Editor",
-    "description": "Excel-like Markdown table editor — multi-sheet workbooks, cross-table lookups, and live sync.",
+    "description": "Excel-like Markdown table editor — multi-sheet workbooks, cross-table lookups. Workbooks load instantly in Python & Node.js scripts.",
     "icon": "images/icon.png",
     "version": "1.4.1",
     "engines": {


### PR DESCRIPTION
## Summary
- Replace the retired shields.io VS Marketplace badge with vsmarketplacebadges.dev (shields.io dropped VS Marketplace badges; the old one rendered as "retired")
- Reorder badges to lead with Open VSX downloads and relabel as "Open VSX downloads" / "VS Code installs" for clarity to non-developers
- Remove the license badge from the header row
- Rewrite the tagline (EN + JA README and package.json description) to drop "live sync" and highlight Python & Node.js script access

## Test plan
- [ ] Verify all three badges render correctly on the GitHub PR page (especially the new vsmarketplacebadges.dev SVG)
- [ ] Confirm EN/JA README headers display the new tagline and badge order
- [ ] Confirm package.json description matches the README tagline